### PR TITLE
API client service - fetch configuration from precomputed API

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -35,5 +35,3 @@ jobs:
         run: make test-data
       - name: Run tests
         run: dart test
-      - name: Run example
-        run: dart run example/eppo_sdk_example.dart

--- a/example/eppo_sdk_example.dart
+++ b/example/eppo_sdk_example.dart
@@ -1,6 +1,0 @@
-import 'package:eppo/eppo_sdk.dart';
-
-void main() {
-  var eppo = Eppo();
-  print('eppo: ${eppo.isAwesome}');
-}

--- a/example/load_precompute_response.dart
+++ b/example/load_precompute_response.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+import 'package:eppo/eppo_sdk.dart';
+import 'package:eppo/src/api_client.dart';
+import 'package:eppo/src/http_client.dart';
+import 'package:eppo/src/sdk_version.dart' as sdk;
+import 'package:eppo/src/subject.dart';
+
+void main(List<String> args) async {
+  // Check for SDK key in arguments
+  if (args.isEmpty) {
+    print(
+      'Usage: dart example/load_precompute_response.dart <sdk-key> [subject-key]',
+    );
+    exit(1);
+  }
+
+  final sdkKey = args[0];
+  final subjectKey = args.length > 1 ? args[1] : 'user-123';
+
+  print('Using SDK key: $sdkKey');
+  print('Using subject key: $subjectKey');
+
+  // Create API client
+  final apiClient = EppoApiClient(
+    sdkKey: sdkKey,
+    sdkVersion: '1.0.0',
+    sdkPlatform: sdk.SdkPlatform.dart,
+    httpClient: DefaultEppoHttpClient(),
+  );
+
+  // Create subject attributes
+  final attributes = ContextAttributes(
+    categoricalAttributes: {'country': 'US', 'device': 'mobile'},
+    numericAttributes: {'age': 30, 'visits': 5},
+  );
+
+  // Fetch precomputed flags
+  final response = await apiClient.fetchPrecomputedFlags(
+    subjectKey: subjectKey,
+    subjectAttributes: attributes,
+  );
+
+  // Print the response
+  print(
+    'Received ${response.flags.length} flags and ${response.bandits.length} bandits',
+  );
+
+  response.flags.forEach((key, flag) {
+    print('Flag: $key');
+    print('allocationKey: ${flag.allocationKey}');
+    print('variationKey: ${flag.variationKey}');
+    print('variationType: ${flag.variationType}');
+    print('variationValue: ${flag.variationValue}');
+    print('');
+  });
+
+  response.bandits.forEach((key, bandit) {
+    print('Bandit: $key');
+    print(bandit);
+  });
+
+  exit(0);
+}

--- a/lib/eppo_sdk.dart
+++ b/lib/eppo_sdk.dart
@@ -5,3 +5,5 @@ library;
 
 export 'src/eppo_sdk_base.dart';
 export 'src/configuration_wire_protocol.dart';
+export 'src/subject.dart';
+export 'src/constants.dart';

--- a/lib/src/api_client.dart
+++ b/lib/src/api_client.dart
@@ -29,9 +29,9 @@ class EppoApiClient {
     String? baseUrl,
     int? requestTimeoutMs,
     EppoHttpClient? httpClient,
-  }) : baseUrl = baseUrl ?? precomputedBaseUrl,
-       requestTimeoutMs = requestTimeoutMs ?? defaultRequestTimeoutMs,
-       _httpClient = httpClient ?? DefaultEppoHttpClient();
+  })  : baseUrl = baseUrl ?? precomputedBaseUrl,
+        requestTimeoutMs = requestTimeoutMs ?? defaultRequestTimeoutMs,
+        _httpClient = httpClient ?? DefaultEppoHttpClient();
 
   /// Fetches precomputed flags for a subject
   Future<ObfuscatedPrecomputedConfigurationResponse> fetchPrecomputedFlags({
@@ -55,7 +55,6 @@ class EppoApiClient {
 
     final url = '$baseUrl$precomputedFlagsEndpoint?$queryString';
 
-    print('Fetching precomputed flags from $url');
     // Prepare the payload
     final payload = {
       'subject_key': subjectKey,

--- a/lib/src/api_client.dart
+++ b/lib/src/api_client.dart
@@ -1,0 +1,79 @@
+import 'package:eppo/eppo_sdk.dart';
+import 'package:eppo/src/http_client.dart';
+import 'package:eppo/src/sdk_version.dart' as sdk;
+
+/// API client for Eppo services
+class EppoApiClient {
+  final EppoHttpClient _httpClient;
+
+  /// SDK key for authentication
+  final String sdkKey;
+
+  /// SDK version
+  final String sdkVersion;
+
+  /// SDK name
+  final sdk.SdkPlatform sdkPlatform;
+
+  /// Base URL for API requests
+  final String baseUrl;
+
+  /// Request timeout in milliseconds
+  final int requestTimeoutMs;
+
+  /// Creates a new API client
+  EppoApiClient({
+    required this.sdkKey,
+    required this.sdkVersion,
+    required this.sdkPlatform,
+    String? baseUrl,
+    int? requestTimeoutMs,
+    EppoHttpClient? httpClient,
+  }) : baseUrl = baseUrl ?? precomputedBaseUrl,
+       requestTimeoutMs = requestTimeoutMs ?? defaultRequestTimeoutMs,
+       _httpClient = httpClient ?? DefaultEppoHttpClient();
+
+  /// Fetches precomputed flags for a subject
+  Future<ObfuscatedPrecomputedConfigurationResponse> fetchPrecomputedFlags({
+    required String subjectKey,
+    required ContextAttributes subjectAttributes,
+    Map<String, Map<String, Map<String, dynamic>>>? banditActions,
+  }) async {
+    // Build URL with query parameters
+    final queryParams = {
+      'apiKey': sdkKey,
+      'sdkVersion': sdkVersion,
+      'sdkName': sdkPlatform.toString(),
+    };
+
+    final queryString = queryParams.entries
+        .map(
+          (e) =>
+              '${Uri.encodeComponent(e.key)}=${Uri.encodeComponent(e.value)}',
+        )
+        .join('&');
+
+    final url = '$baseUrl$precomputedFlagsEndpoint?$queryString';
+
+    print('Fetching precomputed flags from $url');
+    // Prepare the payload
+    final payload = {
+      'subject_key': subjectKey,
+      'subject_attributes': subjectAttributes.toJson(),
+    };
+
+    // Add bandit actions if available
+    if (banditActions != null) {
+      payload['bandit_actions'] = banditActions;
+    }
+
+    final responseData = await _httpClient.post(
+      url,
+      payload,
+      requestTimeoutMs,
+      {},
+    );
+
+    return ObfuscatedPrecomputedConfigurationResponse.fromJson(responseData);
+  }
+}

--- a/lib/src/configuration_wire_protocol.dart
+++ b/lib/src/configuration_wire_protocol.dart
@@ -62,9 +62,6 @@ class ObfuscatedPrecomputedConfigurationResponse {
 
 /// Represents a precomputed flag with a value and type
 class ObfuscatedPrecomputedFlag {
-  /// Optional flag key
-  final MD5String? flagKey;
-
   /// Optional allocation key
   final MD5String? allocationKey;
 
@@ -84,7 +81,6 @@ class ObfuscatedPrecomputedFlag {
   final Base64String variationValue;
 
   ObfuscatedPrecomputedFlag({
-    this.flagKey,
     this.allocationKey,
     this.variationKey,
     required this.variationType,
@@ -95,7 +91,6 @@ class ObfuscatedPrecomputedFlag {
 
   factory ObfuscatedPrecomputedFlag.fromJson(Map<String, dynamic> json) {
     return ObfuscatedPrecomputedFlag(
-      flagKey: json['flagKey'] as MD5String?,
       allocationKey: json['allocationKey'] as MD5String?,
       variationKey: json['variationKey'] as MD5String?,
       variationType: json['variationType'] as String,

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,0 +1,27 @@
+/// Default base URL for Eppo API
+const String precomputedBaseUrl = 'https://fs-edge-assignment.eppo.cloud';
+
+/// Precomputed flags endpoint for fetching assignments
+const String precomputedFlagsEndpoint = '/assignments';
+
+/// Default request timeout in milliseconds
+const int defaultRequestTimeoutMs = 5000;
+
+/// SDK platform enum
+enum SdkPlatform {
+  dart,
+  flutter,
+  other;
+
+  @override
+  String toString() {
+    switch (this) {
+      case SdkPlatform.dart:
+        return 'dart';
+      case SdkPlatform.flutter:
+        return 'flutter';
+      case SdkPlatform.other:
+        return 'other';
+    }
+  }
+}

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -6,22 +6,3 @@ const String precomputedFlagsEndpoint = '/assignments';
 
 /// Default request timeout in milliseconds
 const int defaultRequestTimeoutMs = 5000;
-
-/// SDK platform enum
-enum SdkPlatform {
-  dart,
-  flutter,
-  other;
-
-  @override
-  String toString() {
-    switch (this) {
-      case SdkPlatform.dart:
-        return 'dart';
-      case SdkPlatform.flutter:
-        return 'flutter';
-      case SdkPlatform.other:
-        return 'other';
-    }
-  }
-}

--- a/lib/src/http_client.dart
+++ b/lib/src/http_client.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+/// Exception thrown when an HTTP request fails
+class HttpException implements Exception {
+  final String message;
+
+  HttpException(this.message);
+
+  @override
+  String toString() => 'HttpException: $message';
+}
+
+/// Interface for HTTP client used by the Eppo API client
+abstract class EppoHttpClient {
+  /// Performs a POST request to the specified URL
+  Future<Map<String, dynamic>> post(
+    String url,
+    Map<String, dynamic> payload,
+    int timeoutMs,
+    Map<String, String> headers,
+  );
+}
+
+/// Default implementation of EppoHttpClient using the http package
+class DefaultEppoHttpClient implements EppoHttpClient {
+  final http.Client _client;
+
+  DefaultEppoHttpClient([http.Client? client])
+    : _client = client ?? http.Client();
+
+  @override
+  Future<Map<String, dynamic>> post(
+    String url,
+    Map<String, dynamic> payload,
+    int timeoutMs,
+    Map<String, String> headers,
+  ) async {
+    try {
+      final response = await _client
+          .post(
+            Uri.parse(url),
+            body: jsonEncode(payload),
+            headers: {'Content-Type': 'application/json', ...headers},
+          )
+          .timeout(Duration(milliseconds: timeoutMs));
+
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        return jsonDecode(response.body) as Map<String, dynamic>;
+      } else {
+        throw HttpException(
+          'Request failed with status: ${response.statusCode}',
+        );
+      }
+    } on FormatException {
+      throw FormatException('Invalid JSON response');
+    } on TimeoutException {
+      throw TimeoutException('Request timed out after ${timeoutMs}ms');
+    } catch (e) {
+      if (e is HttpException) rethrow;
+      throw Exception('Network error: $e');
+    }
+  }
+}

--- a/lib/src/sdk_version.dart
+++ b/lib/src/sdk_version.dart
@@ -1,0 +1,39 @@
+/// The current SDK version (private)
+const String _sdkVersion = '1.0.0';
+
+/// Supported SDK platforms
+enum SdkPlatform {
+  /// Dart platform
+  dart,
+
+  /// Flutter web platform
+  flutterWeb,
+
+  /// Flutter iOS platform
+  flutterIos,
+
+  /// Flutter Android platform
+  flutterAndroid,
+}
+
+/// Returns the SDK version
+String getSdkVersion() {
+  return _sdkVersion;
+}
+
+/// Returns the SDK name prefix
+const String _sdkNamePrefix = 'eppo-dart';
+
+/// Returns the SDK name based on platform
+String getSdkName(SdkPlatform platform) {
+  switch (platform) {
+    case SdkPlatform.dart:
+      return _sdkNamePrefix;
+    case SdkPlatform.flutterWeb:
+      return '$_sdkNamePrefix-flutter-client-web';
+    case SdkPlatform.flutterIos:
+      return '$_sdkNamePrefix-flutter-client-ios';
+    case SdkPlatform.flutterAndroid:
+      return '$_sdkNamePrefix-flutter-client-android';
+  }
+}

--- a/lib/src/subject.dart
+++ b/lib/src/subject.dart
@@ -1,0 +1,25 @@
+/// Attributes map type
+typedef Attributes = Map<String, dynamic>;
+
+/// Context attributes with numeric and categorical attributes
+class ContextAttributes {
+  /// Numeric attributes
+  final Attributes numericAttributes;
+
+  /// Categorical attributes
+  final Attributes categoricalAttributes;
+
+  /// Creates a new set of context attributes
+  const ContextAttributes({
+    this.numericAttributes = const {},
+    this.categoricalAttributes = const {},
+  });
+
+  /// Convert to JSON map
+  Map<String, dynamic> toJson() {
+    return {
+      'numericAttributes': numericAttributes,
+      'categoricalAttributes': categoricalAttributes,
+    };
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 repository: https://github.com/eppo/eppo-dart
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 # Add regular dependencies here.
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 repository: https://github.com/eppo/eppo-dart
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=2.19.0 <4.0.0'
 
 # Add regular dependencies here.
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,18 @@
 name: eppo
-description: Eppo SDK for Dart
-version: 0.1.0-alpha.1
+description: Eppo SDK for Dart and Flutter applications
+version: 1.0.0
 repository: https://github.com/eppo/eppo-dart
 
 environment:
-  sdk: ^3.7.0
+  sdk: '>=2.17.0 <4.0.0'
 
 # Add regular dependencies here.
 dependencies:
+  http: ^1.3.0
+  logging: ^1.1.0
   # path: ^1.8.0
 
 dev_dependencies:
   lints: ^5.0.0
-  test: ^1.24.0
+  test: ^1.21.0
+  mockito: ^5.3.0

--- a/test/api_client_test.dart
+++ b/test/api_client_test.dart
@@ -1,0 +1,272 @@
+import 'dart:async';
+import 'package:eppo/src/api_client.dart';
+import 'package:eppo/src/http_client.dart';
+import 'package:eppo/src/sdk_version.dart' as sdk;
+import 'package:test/test.dart';
+import 'package:eppo/src/subject.dart';
+
+class MockEppoHttpClient implements EppoHttpClient {
+  final Map<String, dynamic>? responseData;
+  final Exception? exceptionToThrow;
+  final int? statusCode;
+
+  // Track the last request for verification
+  String? lastUrl;
+  Map<String, dynamic>? lastPayload;
+  int? lastTimeoutMs;
+  Map<String, String>? lastHeaders;
+
+  MockEppoHttpClient({
+    this.responseData,
+    this.exceptionToThrow,
+    this.statusCode,
+  });
+
+  @override
+  Future<Map<String, dynamic>> post(
+    String url,
+    Map<String, dynamic> payload,
+    int timeoutMs,
+    Map<String, String> headers,
+  ) async {
+    // Store request details for verification
+    lastUrl = url;
+    lastPayload = payload;
+    lastTimeoutMs = timeoutMs;
+    lastHeaders = headers;
+
+    // Simulate errors if configured
+    if (exceptionToThrow != null) {
+      throw exceptionToThrow!;
+    }
+
+    if (statusCode != null && (statusCode! < 200 || statusCode! >= 300)) {
+      throw HttpException('Request failed with status: $statusCode');
+    }
+
+    // Return mock response or empty map
+    return responseData ?? {};
+  }
+}
+
+void main() {
+  group('EppoApiClient', () {
+    late MockEppoHttpClient mockHttpClient;
+    late EppoApiClient apiClient;
+
+    const sdkKey = 'test-sdk-key';
+    const sdkVersion = '1.0.0';
+    const baseUrl = 'https://api.test.com';
+    const requestTimeoutMs = 5000;
+
+    setUp(() {
+      mockHttpClient = MockEppoHttpClient();
+      apiClient = EppoApiClient(
+        sdkKey: sdkKey,
+        sdkVersion: sdkVersion,
+        sdkPlatform: sdk.SdkPlatform.dart,
+        baseUrl: baseUrl,
+        requestTimeoutMs: requestTimeoutMs,
+        httpClient: mockHttpClient,
+      );
+    });
+
+    group('fetchPrecomputedFlags', () {
+      test('handles successful response', () async {
+        // Arrange
+        final mockResponse = {
+          'flags': {
+            'test-flag': {'value': 'test-value', 'rule_id': 'rule-1'},
+          },
+          'bandits': {},
+          'salt': 'test-salt',
+          'format': 'json',
+          'obfuscated': false,
+          'createdAt': '2023-01-01T00:00:00Z',
+          'environment': {'name': 'test'},
+        };
+
+        mockHttpClient = MockEppoHttpClient(responseData: mockResponse);
+        apiClient = EppoApiClient(
+          sdkKey: sdkKey,
+          sdkVersion: sdkVersion,
+          sdkPlatform: sdk.SdkPlatform.dart,
+          baseUrl: baseUrl,
+          requestTimeoutMs: requestTimeoutMs,
+          httpClient: mockHttpClient,
+        );
+
+        // Act
+        final result = await apiClient.fetchPrecomputedFlags(
+          subjectKey: 'user-123',
+          subjectAttributes: ContextAttributes(
+            categoricalAttributes: {'country': 'US'},
+          ),
+        );
+
+        // Assert
+        expect(result.flags.length, 1);
+        expect(result.flags['test-flag']?.variationValue, 'test-value');
+        expect(result.salt, 'test-salt');
+
+        // Verify request was made correctly
+        expect(mockHttpClient.lastUrl, contains(baseUrl));
+        expect(mockHttpClient.lastUrl, contains('apiKey=$sdkKey'));
+        expect(mockHttpClient.lastPayload?['subject_key'], 'user-123');
+      });
+
+      test(
+        'throws HttpException when server returns error status code',
+        () async {
+          // Arrange
+          mockHttpClient = MockEppoHttpClient(statusCode: 500);
+          apiClient = EppoApiClient(
+            sdkKey: sdkKey,
+            sdkVersion: sdkVersion,
+            sdkPlatform: sdk.SdkPlatform.dart,
+            baseUrl: baseUrl,
+            requestTimeoutMs: requestTimeoutMs,
+            httpClient: mockHttpClient,
+          );
+
+          // Act & Assert
+          expect(
+            () => apiClient.fetchPrecomputedFlags(
+              subjectKey: 'user-123',
+              subjectAttributes: ContextAttributes(),
+            ),
+            throwsA(isA<HttpException>()),
+          );
+        },
+      );
+
+      test('throws TimeoutException when request times out', () async {
+        // Arrange
+        mockHttpClient = MockEppoHttpClient(
+          exceptionToThrow: TimeoutException('Request timed out'),
+        );
+        apiClient = EppoApiClient(
+          sdkKey: sdkKey,
+          sdkVersion: sdkVersion,
+          sdkPlatform: sdk.SdkPlatform.dart,
+          baseUrl: baseUrl,
+          requestTimeoutMs: requestTimeoutMs,
+          httpClient: mockHttpClient,
+        );
+
+        // Act & Assert
+        expect(
+          () => apiClient.fetchPrecomputedFlags(
+            subjectKey: 'user-123',
+            subjectAttributes: ContextAttributes(),
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+
+      test('throws FormatException when response is not valid JSON', () async {
+        // Arrange
+        mockHttpClient = MockEppoHttpClient(
+          exceptionToThrow: FormatException('Invalid JSON'),
+        );
+        apiClient = EppoApiClient(
+          sdkKey: sdkKey,
+          sdkVersion: sdkVersion,
+          sdkPlatform: sdk.SdkPlatform.dart,
+          baseUrl: baseUrl,
+          requestTimeoutMs: requestTimeoutMs,
+          httpClient: mockHttpClient,
+        );
+
+        // Act & Assert
+        expect(
+          () => apiClient.fetchPrecomputedFlags(
+            subjectKey: 'user-123',
+            subjectAttributes: ContextAttributes(),
+          ),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('handles 401 Unauthorized error', () async {
+        // Arrange
+        mockHttpClient = MockEppoHttpClient(statusCode: 401);
+        apiClient = EppoApiClient(
+          sdkKey: 'invalid-key',
+          sdkVersion: sdkVersion,
+          sdkPlatform: sdk.SdkPlatform.dart,
+          baseUrl: baseUrl,
+          requestTimeoutMs: requestTimeoutMs,
+          httpClient: mockHttpClient,
+        );
+
+        // Act & Assert
+        expect(
+          () => apiClient.fetchPrecomputedFlags(
+            subjectKey: 'user-123',
+            subjectAttributes: ContextAttributes(),
+          ),
+          throwsA(
+            isA<HttpException>().having(
+              (e) => e.message,
+              'message',
+              contains('401'),
+            ),
+          ),
+        );
+      });
+
+      test('handles 404 Not Found error', () async {
+        // Arrange
+        mockHttpClient = MockEppoHttpClient(statusCode: 404);
+        apiClient = EppoApiClient(
+          sdkKey: sdkKey,
+          sdkVersion: sdkVersion,
+          sdkPlatform: sdk.SdkPlatform.dart,
+          baseUrl: 'https://invalid-url.com',
+          requestTimeoutMs: requestTimeoutMs,
+          httpClient: mockHttpClient,
+        );
+
+        // Act & Assert
+        expect(
+          () => apiClient.fetchPrecomputedFlags(
+            subjectKey: 'user-123',
+            subjectAttributes: ContextAttributes(),
+          ),
+          throwsA(
+            isA<HttpException>().having(
+              (e) => e.message,
+              'message',
+              contains('404'),
+            ),
+          ),
+        );
+      });
+
+      test('handles network errors', () async {
+        // Arrange
+        mockHttpClient = MockEppoHttpClient(
+          exceptionToThrow: Exception('Network error'),
+        );
+        apiClient = EppoApiClient(
+          sdkKey: sdkKey,
+          sdkVersion: sdkVersion,
+          sdkPlatform: sdk.SdkPlatform.dart,
+          baseUrl: baseUrl,
+          requestTimeoutMs: requestTimeoutMs,
+          httpClient: mockHttpClient,
+        );
+
+        // Act & Assert
+        expect(
+          () => apiClient.fetchPrecomputedFlags(
+            subjectKey: 'user-123',
+            subjectAttributes: ContextAttributes(),
+          ),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+  });
+}

--- a/test/api_client_test.dart
+++ b/test/api_client_test.dart
@@ -76,14 +76,31 @@ void main() {
         // Arrange
         final mockResponse = {
           'flags': {
-            'test-flag': {'value': 'test-value', 'rule_id': 'rule-1'},
+            'test-flag': {
+              'allocationKey': 'allocation-1',
+              'variationKey': 'variation-1',
+              'variationType': 'string',
+              'extraLogging': {'key1': 'value1'},
+              'doLog': true,
+              'variationValue': 'test-value',
+            },
           },
-          'bandits': {},
+          'bandits': {
+            'test-bandit': {
+              'banditKey': 'bandit-1',
+              'action': 'action-1',
+              'modelVersion': 'v1',
+              'actionNumericAttributes': {'attr1': 'value1'},
+              'actionCategoricalAttributes': {'cat1': 'value1'},
+              'actionProbability': 0.75,
+              'optimalityGap': 0.1,
+            },
+          },
           'salt': 'test-salt',
-          'format': 'json',
-          'obfuscated': false,
+          'format': 'precomputed',
+          'obfuscated': true,
           'createdAt': '2023-01-01T00:00:00Z',
-          'environment': {'name': 'test'},
+          'environment': {'name': 'test-env'},
         };
 
         mockHttpClient = MockEppoHttpClient(responseData: mockResponse);
@@ -107,6 +124,7 @@ void main() {
         // Assert
         expect(result.flags.length, 1);
         expect(result.flags['test-flag']?.variationValue, 'test-value');
+        expect(result.flags['test-flag']?.variationType, 'string');
         expect(result.salt, 'test-salt');
 
         // Verify request was made correctly

--- a/test/sdk_version_test.dart
+++ b/test/sdk_version_test.dart
@@ -1,0 +1,37 @@
+import 'package:eppo/src/sdk_version.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SDK Version', () {
+    test('getSdkVersion returns correct version', () {
+      expect(getSdkVersion(), '1.0.0');
+    });
+
+    test('getSdkName returns correct name for dart platform', () {
+      expect(getSdkName(SdkPlatform.dart), 'eppo-dart');
+    });
+
+    test('getSdkName returns correct name for Flutter platforms', () {
+      expect(
+        getSdkName(SdkPlatform.flutterWeb),
+        'eppo-dart-flutter-client-web',
+      );
+      expect(
+        getSdkName(SdkPlatform.flutterIos),
+        'eppo-dart-flutter-client-ios',
+      );
+      expect(
+        getSdkName(SdkPlatform.flutterAndroid),
+        'eppo-dart-flutter-client-android',
+      );
+    });
+
+    test('SdkPlatform enum has expected values', () {
+      expect(SdkPlatform.values.length, 4);
+      expect(SdkPlatform.values, contains(SdkPlatform.dart));
+      expect(SdkPlatform.values, contains(SdkPlatform.flutterWeb));
+      expect(SdkPlatform.values, contains(SdkPlatform.flutterIos));
+      expect(SdkPlatform.values, contains(SdkPlatform.flutterAndroid));
+    });
+  });
+}


### PR DESCRIPTION
## Capabilities

* Perform a POST against the precomputed API endpoint
* Serialize response to Dart-types

## Testing

1️⃣ new unit tests

* api_client accepts a mock http class and validates handling error conditions

2️⃣  run example app locally with the goal of demonstrated precomputed assignments are fetch and deserialized:

```
✗ dart run example/load_precompute_response.dart abc.

Using SDK key: abc
Using subject key: user-123

Received 38 flags and 0 bandits

Flag: 0517e4f304cc211502b3f210b7a47c90
allocationKey: YWxsb2NhdGlvbi0xNjU4NA==
variationKey: aGVsbG8td29ybGQ=
variationType: STRING
value: aGVsbG8td29ybGQ=

Flag: fcf5c5d998a8f3319dc5d9b06c9fd5ca
allocationKey: YWxsb2NhdGlvbi0xMzUzMQ==
variationKey: dHJlYXRtZW50
variationType: STRING
value: dHJlYXRtZW50

Flag: 33bd3d323c384152b4e67bc5af8a0cc6
allocationKey: YWxsb2NhdGlvbi0xOTU0MQ==
variationKey: dHJ1ZQ==
variationType: BOOLEAN
value: dHJ1ZQ==
```