### PR TITLE
feat: add support for an optional assignment logger callback

### DIFF
--- a/lib/eppo_sdk.dart
+++ b/lib/eppo_sdk.dart
@@ -13,3 +13,4 @@ export 'src/http_client.dart';
 export 'src/sdk_version.dart';
 export 'src/configuration_store.dart';
 export 'src/crypto.dart';
+export 'src/assignment_logger.dart';

--- a/lib/src/assignment_logger.dart
+++ b/lib/src/assignment_logger.dart
@@ -1,0 +1,68 @@
+/// Represents an event for logging an assignment
+class AssignmentEvent {
+  /// The allocation the subject was assigned to
+  final String? allocation;
+
+  /// The experiment identifier
+  final String? experiment;
+
+  /// The feature flag identifier
+  final String featureFlag;
+
+  /// The format of the assignment
+  final String format;
+
+  /// The variation key that was assigned
+  final String? variation;
+
+  /// The subject identifier
+  final String subject;
+
+  /// The timestamp of the assignment
+  final String timestamp;
+
+  /// The subject attributes
+  final Map<String, dynamic>? subjectAttributes;
+
+  /// Additional metadata
+  final Map<String, dynamic>? metaData;
+
+  /// Details about the evaluation
+  final Map<String, dynamic>? evaluationDetails;
+
+  /// Creates a new assignment event
+  const AssignmentEvent({
+    this.allocation,
+    this.experiment,
+    required this.featureFlag,
+    required this.format,
+    this.variation,
+    required this.subject,
+    required this.timestamp,
+    this.subjectAttributes,
+    this.metaData,
+    this.evaluationDetails,
+  });
+
+  /// Converts this assignment event to a JSON map
+  Map<String, dynamic> toJson() {
+    return {
+      if (allocation != null) 'allocation': allocation,
+      if (experiment != null) 'experiment': experiment,
+      'featureFlag': featureFlag,
+      'format': format,
+      if (variation != null) 'variation': variation,
+      'subject': subject,
+      'timestamp': timestamp,
+      if (subjectAttributes != null) 'subjectAttributes': subjectAttributes,
+      if (metaData != null) 'metaData': metaData,
+      if (evaluationDetails != null) 'evaluationDetails': evaluationDetails,
+    };
+  }
+}
+
+/// Interface for logging assignment events
+abstract class AssignmentLogger {
+  /// Logs an assignment event
+  void logAssignment(AssignmentEvent event);
+}

--- a/lib/src/precompute_client.dart
+++ b/lib/src/precompute_client.dart
@@ -12,6 +12,9 @@ class SdkOptions {
   /// Platform for the SDK
   final sdk.SdkPlatform sdkPlatform;
 
+  /// Assignment logger
+  final AssignmentLogger? assignmentLogger;
+
   /// Base URL for API requests
   final String? baseUrl;
 
@@ -28,6 +31,7 @@ class SdkOptions {
   const SdkOptions({
     required this.sdkKey,
     required this.sdkPlatform,
+    this.assignmentLogger,
     this.baseUrl,
     this.requestTimeoutMs,
     this.throwOnFailedInitialization,
@@ -56,6 +60,10 @@ class EppoPrecomputedClient {
   final ConfigurationStore<ObfuscatedPrecomputedFlag> _precomputedFlagStore;
   EppoApiClient? _apiClient;
   final Logger _logger = Logger('EppoPrecomputedClient');
+
+  // TODO: Add assignment cache
+  /// Cache for tracking logged assignments to prevent duplicates
+  // AssignmentCache? assignmentCache;
 
   /// Creates a new precomputed client
   EppoPrecomputedClient(SdkOptions sdkOptions, PrecomputeArguments precompute)
@@ -205,29 +213,33 @@ class EppoPrecomputedClient {
     final decodedValue = decodeValue(precomputedFlag.variationValue,
         precomputedFlag.variationType.toString().split('.').last);
 
-    final result = {
-      'flagKey': flagKey,
-      'format': _precomputedFlagStore.getFormat() ?? '',
-      'subjectKey': _precompute.subject.subjectKey,
-      'subjectAttributes': _precompute.subject.subjectAttributes,
-      'variation': {
-        'key': precomputedFlag.variationKey != null
+    final result = FlagEvaluation(
+      flagKey: flagKey,
+      format: _precomputedFlagStore.getFormat() ?? '',
+      subjectKey: _precompute.subject.subjectKey,
+      subjectAttributes: _precompute.subject.subjectAttributes,
+      variation: Variation(
+        key: precomputedFlag.variationKey != null
             ? decodeBase64(precomputedFlag.variationKey!)
             : '',
-        'value': decodedValue,
-      },
-      'allocationKey': precomputedFlag.allocationKey != null
+        value: decodedValue,
+      ),
+      allocationKey: precomputedFlag.allocationKey != null
           ? decodeBase64(precomputedFlag.allocationKey!)
           : '',
-      'extraLogging': precomputedFlag.extraLogging != null
+      extraLogging: precomputedFlag.extraLogging != null
           ? decodeStringMap(precomputedFlag.extraLogging!)
           : {},
-      'doLog': precomputedFlag.doLog,
-    };
+      doLog: precomputedFlag.doLog,
+    );
 
     try {
-      final variation = result['variation'] as Map<String, dynamic>?;
-      final variationValue = variation?['value'];
+      final variation = result.variation;
+      final variationValue = variation?.value;
+
+      if (result.doLog) {
+        _logAssignment(result);
+      }
 
       if (variationValue != null) {
         return valueTransformer != null
@@ -241,6 +253,70 @@ class EppoPrecomputedClient {
     }
   }
 
+  void _logAssignment(FlagEvaluation result) {
+    final flagKey = result.flagKey;
+    final subjectKey = result.subjectKey;
+    final allocationKey = result.allocationKey;
+    final subjectAttributes = result.subjectAttributes;
+    final variation = result.variation;
+    final format = result.format;
+
+    // Create the assignment event
+    final event = AssignmentEvent(
+      allocation: allocationKey,
+      experiment: allocationKey != null ? '$flagKey-$allocationKey' : null,
+      featureFlag: flagKey,
+      format: format,
+      variation: variation?.key,
+      subject: subjectKey,
+      timestamp: DateTime.now().toIso8601String(),
+      subjectAttributes: subjectAttributes.toJson(),
+      metaData: _buildLoggerMetadata(),
+      evaluationDetails: null,
+    );
+
+    // TODO: Add assignment cache
+    // Check if we've already logged this assignment
+    // if (variation != null && allocationKey != null) {
+    //   final hasLoggedAssignment = assignmentCache?.has(
+    //     flagKey: flagKey,
+    //     subjectKey: subjectKey,
+    //     allocationKey: allocationKey,
+    //     variationKey: variation.key,
+    //   );
+
+    //   if (hasLoggedAssignment == true) {
+    //     return;
+    //   }
+    // }
+
+    // TODO: Add assignments to queue to flush.
+    try {
+      if (_sdkOptions.assignmentLogger != null) {
+        _sdkOptions.assignmentLogger!.logAssignment(event);
+      }
+
+      // Update the assignment cache
+      // assignmentCache?.set(
+      //   flagKey: flagKey,
+      //   subjectKey: subjectKey,
+      //   allocationKey: allocationKey ?? '__eppo_no_allocation',
+      //   variationKey: variation?.key ?? '__eppo_no_variation',
+      // );
+    } catch (error) {
+      _logger.severe(
+          '$defaultLoggerPrefix Error logging assignment event: $error');
+    }
+  }
+
+  /// Builds metadata for the logger
+  Map<String, dynamic> _buildLoggerMetadata() {
+    return {
+      'sdkVersion': sdk.getSdkVersion(),
+      'sdkName': sdk.SdkPlatform.dart.toString(),
+    };
+  }
+
   ObfuscatedPrecomputedFlag? _getPrecomputedFlag(String flagKey) {
     final salt = _precomputedFlagStore.salt;
 
@@ -250,14 +326,91 @@ class EppoPrecomputedClient {
     }
 
     final saltedAndHashedFlagKey = getMD5Hash(flagKey, salt);
-    final flag = _precomputedFlagStore.get(saltedAndHashedFlagKey);
+    return _precomputedFlagStore.get(saltedAndHashedFlagKey);
+  }
+}
 
-    if (flag == null) {
-      return null;
-    }
+/// Represents a variation in a feature flag
+class Variation {
+  /// The key of the variation
+  final String key;
 
-    // No need to decode here - we'll decode the values when they're accessed
-    // in the _getPrecomputedAssignment method
-    return flag;
+  /// The value of the variation (can be string, number, or boolean)
+  final dynamic value;
+
+  /// Creates a new variation
+  const Variation({
+    required this.key,
+    required this.value,
+  });
+
+  /// Converts this variation to a JSON map
+  Map<String, dynamic> toJson() {
+    return {
+      'key': key,
+      'value': value,
+    };
+  }
+
+  /// Creates a variation from a JSON map
+  factory Variation.fromJson(Map<String, dynamic> json) {
+    return Variation(
+      key: json['key'] as String,
+      value: json['value'],
+    );
+  }
+}
+
+/// Represents the result of a flag evaluation without detailed information
+class FlagEvaluation {
+  /// The key of the flag being evaluated
+  final String flagKey;
+
+  /// The format of the flag evaluation
+  final String format;
+
+  /// The key of the subject being evaluated
+  final String subjectKey;
+
+  /// The attributes of the subject
+  final ContextAttributes subjectAttributes;
+
+  /// The key of the allocation, if any
+  final String? allocationKey;
+
+  /// The variation assigned to the subject
+  final Variation? variation;
+
+  /// Extra logging information
+  final Map<String, String> extraLogging;
+
+  /// Whether to log this evaluation as an assignment event
+  final bool doLog;
+
+  /// Creates a new flag evaluation result
+  const FlagEvaluation({
+    required this.flagKey,
+    required this.format,
+    required this.subjectKey,
+    required this.subjectAttributes,
+    this.allocationKey,
+    this.variation,
+    Map<String, String>? extraLogging,
+    bool? doLog,
+  })  : this.extraLogging = extraLogging ?? const {},
+        this.doLog = doLog ?? false;
+
+  /// Converts this evaluation to a JSON map
+  Map<String, dynamic> toJson() {
+    return {
+      'flagKey': flagKey,
+      'format': format,
+      'subjectKey': subjectKey,
+      'subjectAttributes': subjectAttributes.toJson(),
+      if (allocationKey != null) 'allocationKey': allocationKey,
+      if (variation != null) 'variation': variation?.toJson(),
+      'extraLogging': extraLogging,
+      'doLog': doLog,
+    };
   }
 }

--- a/lib/src/precompute_client.dart
+++ b/lib/src/precompute_client.dart
@@ -397,8 +397,8 @@ class FlagEvaluation {
     this.variation,
     Map<String, String>? extraLogging,
     bool? doLog,
-  })  : this.extraLogging = extraLogging ?? const {},
-        this.doLog = doLog ?? false;
+  })  : extraLogging = extraLogging ?? const {},
+        doLog = doLog ?? false;
 
   /// Converts this evaluation to a JSON map
   Map<String, dynamic> toJson() {

--- a/test/assignment_logger_test.dart
+++ b/test/assignment_logger_test.dart
@@ -1,0 +1,206 @@
+import 'dart:convert';
+import 'package:eppo/eppo_sdk.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AssignmentEvent', () {
+    test('constructor sets all properties correctly', () {
+      final timestamp = DateTime.now().toIso8601String();
+      final event = AssignmentEvent(
+        allocation: 'test-allocation',
+        experiment: 'test-experiment',
+        featureFlag: 'test-flag',
+        format: 'v1',
+        variation: 'test-variation',
+        subject: 'user-123',
+        timestamp: timestamp,
+        subjectAttributes: {'country': 'US', 'age': 30},
+        metaData: {'source': 'test'},
+        evaluationDetails: {'rule': 'default'},
+      );
+
+      expect(event.allocation, equals('test-allocation'));
+      expect(event.experiment, equals('test-experiment'));
+      expect(event.featureFlag, equals('test-flag'));
+      expect(event.format, equals('v1'));
+      expect(event.variation, equals('test-variation'));
+      expect(event.subject, equals('user-123'));
+      expect(event.timestamp, equals(timestamp));
+      expect(event.subjectAttributes, equals({'country': 'US', 'age': 30}));
+      expect(event.metaData, equals({'source': 'test'}));
+      expect(event.evaluationDetails, equals({'rule': 'default'}));
+    });
+
+    group('toJson', () {
+      test('includes all non-null properties', () {
+        final timestamp = DateTime.now().toIso8601String();
+        final event = AssignmentEvent(
+          allocation: 'test-allocation',
+          experiment: 'test-experiment',
+          featureFlag: 'test-flag',
+          format: 'v1',
+          variation: 'test-variation',
+          subject: 'user-123',
+          timestamp: timestamp,
+          subjectAttributes: {'country': 'US', 'age': 30},
+          metaData: {'source': 'test'},
+          evaluationDetails: {'rule': 'default'},
+        );
+
+        final json = event.toJson();
+
+        expect(json['allocation'], equals('test-allocation'));
+        expect(json['experiment'], equals('test-experiment'));
+        expect(json['featureFlag'], equals('test-flag'));
+        expect(json['format'], equals('v1'));
+        expect(json['variation'], equals('test-variation'));
+        expect(json['subject'], equals('user-123'));
+        expect(json['timestamp'], equals(timestamp));
+        expect(json['subjectAttributes'], equals({'country': 'US', 'age': 30}));
+        expect(json['metaData'], equals({'source': 'test'}));
+        expect(json['evaluationDetails'], equals({'rule': 'default'}));
+      });
+
+      test('excludes null properties', () {
+        final timestamp = DateTime.now().toIso8601String();
+        final event = AssignmentEvent(
+          featureFlag: 'test-flag',
+          format: 'v1',
+          subject: 'user-123',
+          timestamp: timestamp,
+        );
+
+        final json = event.toJson();
+
+        expect(json.containsKey('allocation'), isFalse);
+        expect(json.containsKey('experiment'), isFalse);
+        expect(json['featureFlag'], equals('test-flag'));
+        expect(json['format'], equals('v1'));
+        expect(json.containsKey('variation'), isFalse);
+        expect(json['subject'], equals('user-123'));
+        expect(json['timestamp'], equals(timestamp));
+        expect(json.containsKey('subjectAttributes'), isFalse);
+        expect(json.containsKey('metaData'), isFalse);
+        expect(json.containsKey('evaluationDetails'), isFalse);
+      });
+
+      test('can be encoded to JSON string', () {
+        final timestamp = DateTime.now().toIso8601String();
+        final event = AssignmentEvent(
+          allocation: 'test-allocation',
+          experiment: 'test-experiment',
+          featureFlag: 'test-flag',
+          format: 'v1',
+          variation: 'test-variation',
+          subject: 'user-123',
+          timestamp: timestamp,
+          subjectAttributes: {'country': 'US', 'age': 30},
+          metaData: {'source': 'test'},
+          evaluationDetails: {'rule': 'default'},
+        );
+
+        final jsonString = jsonEncode(event.toJson());
+
+        // Verify that the string is valid JSON
+        expect(() => jsonDecode(jsonString), returnsNormally);
+
+        // Verify that the decoded JSON matches the original
+        final decodedJson = jsonDecode(jsonString) as Map<String, dynamic>;
+        expect(decodedJson['allocation'], equals('test-allocation'));
+        expect(decodedJson['experiment'], equals('test-experiment'));
+        expect(decodedJson['featureFlag'], equals('test-flag'));
+        expect(decodedJson['format'], equals('v1'));
+        expect(decodedJson['variation'], equals('test-variation'));
+        expect(decodedJson['subject'], equals('user-123'));
+        expect(decodedJson['timestamp'], equals(timestamp));
+        expect(decodedJson['subjectAttributes'], isA<Map>());
+        expect(decodedJson['subjectAttributes']['country'], equals('US'));
+        expect(decodedJson['subjectAttributes']['age'], equals(30));
+      });
+
+      test('handles complex nested structures', () {
+        final timestamp = DateTime.now().toIso8601String();
+        final event = AssignmentEvent(
+          featureFlag: 'test-flag',
+          format: 'v1',
+          subject: 'user-123',
+          timestamp: timestamp,
+          subjectAttributes: {
+            'country': 'US',
+            'age': 30,
+            'preferences': {
+              'theme': 'dark',
+              'notifications': true,
+              'favorites': [1, 2, 3],
+            },
+            'history': [
+              {'date': '2023-01-01', 'action': 'login'},
+              {'date': '2023-01-02', 'action': 'purchase'},
+            ],
+          },
+        );
+
+        final jsonString = jsonEncode(event.toJson());
+
+        // Verify that the string is valid JSON
+        expect(() => jsonDecode(jsonString), returnsNormally);
+
+        // Verify that the complex nested structures are preserved
+        final decodedJson = jsonDecode(jsonString) as Map<String, dynamic>;
+        final attrs = decodedJson['subjectAttributes'] as Map<String, dynamic>;
+
+        expect(attrs['country'], equals('US'));
+        expect(attrs['age'], equals(30));
+
+        final prefs = attrs['preferences'] as Map<String, dynamic>;
+        expect(prefs['theme'], equals('dark'));
+        expect(prefs['notifications'], isTrue);
+        expect(prefs['favorites'], equals([1, 2, 3]));
+
+        final history = attrs['history'] as List;
+        expect(history.length, equals(2));
+        expect(history[0]['date'], equals('2023-01-01'));
+        expect(history[0]['action'], equals('login'));
+        expect(history[1]['date'], equals('2023-01-02'));
+        expect(history[1]['action'], equals('purchase'));
+      });
+    });
+  });
+
+  group('AssignmentLogger', () {
+    test('interface can be implemented', () {
+      // Create a simple implementation of AssignmentLogger
+      final logger = _TestAssignmentLogger();
+
+      // Verify that it can be used as an AssignmentLogger
+      AssignmentLogger typedLogger = logger;
+
+      // Create a test event
+      final event = AssignmentEvent(
+        featureFlag: 'test-flag',
+        format: 'v1',
+        subject: 'user-123',
+        timestamp: DateTime.now().toIso8601String(),
+      );
+
+      // Log the event
+      typedLogger.logAssignment(event);
+
+      // Verify that the event was logged
+      expect(logger.lastEvent, equals(event));
+      expect(logger.lastEventJson, equals(event.toJson()));
+    });
+  });
+}
+
+// Simple implementation of AssignmentLogger for testing
+class _TestAssignmentLogger implements AssignmentLogger {
+  AssignmentEvent? lastEvent;
+  Map<String, dynamic>? lastEventJson;
+
+  @override
+  void logAssignment(AssignmentEvent event) {
+    lastEvent = event;
+    lastEventJson = event.toJson();
+  }
+}

--- a/test/precompute_client_test.dart
+++ b/test/precompute_client_test.dart
@@ -1,9 +1,5 @@
-import 'package:eppo/src/api_client.dart';
-import 'package:eppo/src/crypto.dart';
-import 'package:eppo/src/http_client.dart';
-import 'package:eppo/src/precompute_client.dart';
+import 'package:eppo/eppo_sdk.dart';
 import 'package:eppo/src/sdk_version.dart' as sdk;
-import 'package:eppo/src/subject.dart';
 import 'package:test/test.dart';
 
 class MockEppoHttpClient implements EppoHttpClient {
@@ -22,11 +18,26 @@ class MockEppoHttpClient implements EppoHttpClient {
   }
 }
 
+/// Mock implementation of AssignmentLogger for testing
+class MockAssignmentLogger implements AssignmentLogger {
+  final List<AssignmentEvent> loggedEvents = [];
+
+  @override
+  void logAssignment(AssignmentEvent event) {
+    loggedEvents.add(event);
+  }
+
+  void clear() {
+    loggedEvents.clear();
+  }
+}
+
 void main() {
   group('EppoPrecomputedClient', () {
     late EppoPrecomputedClient client;
     late EppoApiClient apiClient;
     late MockEppoHttpClient mockHttpClient;
+    late MockAssignmentLogger mockLogger;
 
     const sdkKey = 'test-sdk-key';
     const subjectKey = 'user-123';
@@ -109,10 +120,12 @@ void main() {
       );
 
       // Create SDK options
+      mockLogger = MockAssignmentLogger();
       final sdkOptions = SdkOptions(
         sdkKey: sdkKey,
         sdkPlatform: sdk.SdkPlatform.dart,
         apiClient: apiClient,
+        assignmentLogger: mockLogger,
       );
 
       // Create precompute arguments
@@ -162,6 +175,44 @@ void main() {
       // Try to get a string flag as a boolean
       final result = client.getBooleanAssignment('string-flag', false);
       expect(result, false);
+    });
+
+    group('Assignment Logging', () {
+      test('logs all assignments when doLog is true', () {
+        // Clear any previous events
+        mockLogger.clear();
+
+        // Get a flag value - this should trigger logging since doLog is true in the mock response
+        client.getStringAssignment('string-flag', 'default');
+        client.getStringAssignment('string-flag', 'default');
+
+        // Verify that an event was logged
+        expect(mockLogger.loggedEvents, hasLength(2));
+
+        // Verify the logged event details
+        final event = mockLogger.loggedEvents.first;
+        expect(event.featureFlag, equals('string-flag'));
+        expect(event.subject, equals(subjectKey));
+        expect(event.variation, equals('variation-1'));
+        expect(event.allocation, equals('allocation-1'));
+        expect(event.experiment, equals('string-flag-allocation-1'));
+      });
+
+      test('logs different flag assignments separately', () {
+        // Clear any previous events
+        mockLogger.clear();
+
+        // Get different flag values
+        client.getStringAssignment('string-flag', 'default');
+        client.getBooleanAssignment('boolean-flag', false);
+
+        // Verify that both events were logged
+        expect(mockLogger.loggedEvents, hasLength(2));
+
+        // Verify the logged event details
+        expect(mockLogger.loggedEvents[0].featureFlag, equals('string-flag'));
+        expect(mockLogger.loggedEvents[1].featureFlag, equals('boolean-flag'));
+      });
     });
   });
 }


### PR DESCRIPTION
## Capabilities

After obtaining a successful variation, if the `doLog` flag is set on the allocation, the optional assignment logger will be invoked.

Next PRs:

* assignment logger cache
* bandit eval
* bandit cache

## Testing

* augmented client tests with logger count
* assignment event serialization