### PR TITLE
add assignment cache implementation in-memory

### DIFF
--- a/lib/eppo_sdk.dart
+++ b/lib/eppo_sdk.dart
@@ -14,3 +14,4 @@ export 'src/sdk_version.dart';
 export 'src/configuration_store.dart';
 export 'src/crypto.dart';
 export 'src/assignment_logger.dart';
+export 'src/assignment_cache.dart';

--- a/lib/src/assignment_cache.dart
+++ b/lib/src/assignment_cache.dart
@@ -1,0 +1,159 @@
+import 'package:eppo/src/crypto.dart';
+
+/// Assignment cache keys are only on the subject and flag level, while the entire value is used
+/// for uniqueness checking. This way if an assigned variation changes for a
+/// flag, it evicts the old one. Then, if an older assignment is later reassigned, it will be treated
+/// as new.
+class AssignmentCacheKey {
+  /// The subject identifier
+  final String subjectKey;
+
+  /// The flag identifier
+  final String flagKey;
+
+  /// Creates a new assignment cache key
+  const AssignmentCacheKey({
+    required this.subjectKey,
+    required this.flagKey,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AssignmentCacheKey &&
+          runtimeType == other.runtimeType &&
+          subjectKey == other.subjectKey &&
+          flagKey == other.flagKey;
+
+  @override
+  int get hashCode => subjectKey.hashCode ^ flagKey.hashCode;
+}
+
+/// Cache value for variation assignments
+class VariationCacheValue {
+  /// The allocation key
+  final String allocationKey;
+
+  /// The variation key
+  final String variationKey;
+
+  /// Creates a new variation cache value
+  const VariationCacheValue({
+    required this.allocationKey,
+    required this.variationKey,
+  });
+
+  /// Converts the value to a map
+  Map<String, String> toMap() => {
+        'allocationKey': allocationKey,
+        'variationKey': variationKey,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is VariationCacheValue &&
+          runtimeType == other.runtimeType &&
+          allocationKey == other.allocationKey &&
+          variationKey == other.variationKey;
+
+  @override
+  int get hashCode => allocationKey.hashCode ^ variationKey.hashCode;
+}
+
+/// Type alias for assignment cache values
+typedef AssignmentCacheValue = VariationCacheValue;
+
+/// Combined key and value for an assignment cache entry
+class AssignmentCacheEntry {
+  /// The cache key
+  final AssignmentCacheKey key;
+
+  /// The cache value
+  final AssignmentCacheValue value;
+
+  /// Creates a new assignment cache entry
+  const AssignmentCacheEntry({
+    required this.key,
+    required this.value,
+  });
+}
+
+/// Converts an [AssignmentCacheKey] to a string.
+String assignmentCacheKeyToString(AssignmentCacheKey key) {
+  return getMD5Hash('${key.subjectKey};${key.flagKey}');
+}
+
+/// Converts an [AssignmentCacheValue] to a string.
+String assignmentCacheValueToString(AssignmentCacheValue value) {
+  return getMD5Hash('${value.allocationKey};${value.variationKey}');
+}
+
+/// Interface for an assignment cache
+abstract class AssignmentCache {
+  /// Sets an entry in the cache
+  void set(AssignmentCacheEntry entry);
+
+  /// Checks if an entry exists in the cache
+  bool has(AssignmentCacheEntry entry);
+}
+
+/// Abstract base class for assignment caches
+abstract class AbstractAssignmentCache implements AssignmentCache {
+  /// The delegate map
+  final Map<String, String> delegate;
+
+  /// Creates a new abstract assignment cache
+  AbstractAssignmentCache(this.delegate);
+
+  /// Returns whether the provided [AssignmentCacheEntry] is present in the cache.
+  @override
+  bool has(AssignmentCacheEntry entry) {
+    return get(entry.key) == assignmentCacheValueToString(entry.value);
+  }
+
+  /// Gets a value from the cache
+  String? get(AssignmentCacheKey key) {
+    return delegate[assignmentCacheKeyToString(key)];
+  }
+
+  /// Stores the provided [AssignmentCacheEntry] in the cache. If the key already exists, it
+  /// will be overwritten.
+  @override
+  void set(AssignmentCacheEntry entry) {
+    delegate[assignmentCacheKeyToString(entry.key)] =
+        assignmentCacheValueToString(entry.value);
+  }
+
+  /// Returns an iterable of all entries in the cache
+  Iterable<MapEntry<String, String>> entries() {
+    return delegate.entries;
+  }
+}
+
+/// A cache that never expires.
+///
+/// The primary use case is for client-side SDKs, where the cache is only used
+/// for a single user.
+class InMemoryAssignmentCache extends AbstractAssignmentCache {
+  /// Creates a new in-memory assignment cache
+  InMemoryAssignmentCache([Map<String, String>? store])
+      : super(store ?? <String, String>{});
+}
+
+/// No-op implementation of the assignment cache that disables caching
+///
+/// This implementation always returns false for has() and does nothing for set(),
+/// effectively disabling assignment deduplication.
+class NoOpAssignmentCache implements AssignmentCache {
+  @override
+  bool has(AssignmentCacheEntry entry) {
+    // Always return false to disable caching
+    return false;
+  }
+
+  @override
+  void set(AssignmentCacheEntry entry) {
+    // Do nothing
+  }
+}

--- a/lib/src/crypto.dart
+++ b/lib/src/crypto.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 import 'package:crypto/crypto.dart';
 
 /// Generates an MD5 hash of the input string with the given salt
-String getMD5Hash(String input, String salt) {
-  final saltedInput = '$salt$input';
+String getMD5Hash(String input, {String? salt}) {
+  final saltedInput = salt != null ? '$salt$input' : input;
   final bytes = utf8.encode(saltedInput);
   final digest = md5.convert(bytes);
   return digest.toString();

--- a/test/assignment_cache_test.dart
+++ b/test/assignment_cache_test.dart
@@ -1,0 +1,176 @@
+import 'package:eppo/src/assignment_cache.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AssignmentCacheKey', () {
+    test('equality works correctly', () {
+      final key1 = AssignmentCacheKey(subjectKey: 'user1', flagKey: 'flag1');
+      final key2 = AssignmentCacheKey(subjectKey: 'user1', flagKey: 'flag1');
+      final key3 = AssignmentCacheKey(subjectKey: 'user2', flagKey: 'flag1');
+
+      expect(key1, equals(key2));
+      expect(key1, isNot(equals(key3)));
+      expect(key1.hashCode, equals(key2.hashCode));
+      expect(key1.hashCode, isNot(equals(key3.hashCode)));
+    });
+  });
+
+  group('VariationCacheValue', () {
+    test('toMap returns correct map', () {
+      final value = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation1',
+      );
+
+      expect(
+          value.toMap(),
+          equals({
+            'allocationKey': 'allocation1',
+            'variationKey': 'variation1',
+          }));
+    });
+
+    test('equality works correctly', () {
+      final value1 = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation1',
+      );
+      final value2 = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation1',
+      );
+      final value3 = VariationCacheValue(
+        allocationKey: 'allocation2',
+        variationKey: 'variation1',
+      );
+
+      expect(value1, equals(value2));
+      expect(value1, isNot(equals(value3)));
+      expect(value1.hashCode, equals(value2.hashCode));
+      expect(value1.hashCode, isNot(equals(value3.hashCode)));
+    });
+  });
+
+  group('assignmentCacheKeyToString', () {
+    test('returns consistent hash for same key', () {
+      final key1 = AssignmentCacheKey(subjectKey: 'user1', flagKey: 'flag1');
+      final key2 = AssignmentCacheKey(subjectKey: 'user1', flagKey: 'flag1');
+
+      expect(assignmentCacheKeyToString(key1),
+          equals(assignmentCacheKeyToString(key2)));
+    });
+
+    test('returns different hash for different keys', () {
+      final key1 = AssignmentCacheKey(subjectKey: 'user1', flagKey: 'flag1');
+      final key2 = AssignmentCacheKey(subjectKey: 'user2', flagKey: 'flag1');
+
+      expect(assignmentCacheKeyToString(key1),
+          isNot(equals(assignmentCacheKeyToString(key2))));
+    });
+  });
+
+  group('assignmentCacheValueToString', () {
+    test('returns consistent hash for same variation value', () {
+      final value1 = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation1',
+      );
+      final value2 = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation1',
+      );
+
+      expect(assignmentCacheValueToString(value1),
+          equals(assignmentCacheValueToString(value2)));
+    });
+
+    test('returns different hash for different variation values', () {
+      final value1 = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation1',
+      );
+      final value2 = VariationCacheValue(
+        allocationKey: 'allocation2',
+        variationKey: 'variation1',
+      );
+
+      expect(assignmentCacheValueToString(value1),
+          isNot(equals(assignmentCacheValueToString(value2))));
+    });
+  });
+
+  group('InMemoryAssignmentCache', () {
+    late InMemoryAssignmentCache cache;
+
+    setUp(() {
+      cache = InMemoryAssignmentCache();
+    });
+
+    test('set and has work correctly for variation entries', () {
+      final key = AssignmentCacheKey(subjectKey: 'user1', flagKey: 'flag1');
+      final value = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation1',
+      );
+      final entry = AssignmentCacheEntry(key: key, value: value);
+
+      expect(cache.has(entry), isFalse);
+
+      cache.set(entry);
+
+      expect(cache.has(entry), isTrue);
+    });
+
+    test('set overwrites existing entries', () {
+      final key = AssignmentCacheKey(subjectKey: 'user1', flagKey: 'flag1');
+      final value1 = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation1',
+      );
+      final entry1 = AssignmentCacheEntry(key: key, value: value1);
+
+      cache.set(entry1);
+      expect(cache.has(entry1), isTrue);
+
+      final value2 = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation2',
+      );
+      final entry2 = AssignmentCacheEntry(key: key, value: value2);
+
+      cache.set(entry2);
+      expect(cache.has(entry1), isFalse);
+      expect(cache.has(entry2), isTrue);
+    });
+
+    test('entries returns all entries', () {
+      final key1 = AssignmentCacheKey(subjectKey: 'user1', flagKey: 'flag1');
+      final value1 = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation1',
+      );
+      final entry1 = AssignmentCacheEntry(key: key1, value: value1);
+
+      final key2 = AssignmentCacheKey(subjectKey: 'user2', flagKey: 'flag1');
+      final value2 = VariationCacheValue(
+        allocationKey: 'allocation1',
+        variationKey: 'variation2',
+      );
+      final entry2 = AssignmentCacheEntry(key: key2, value: value2);
+
+      cache.set(entry1);
+      cache.set(entry2);
+
+      final entries = cache.entries().toList();
+      expect(entries.length, equals(2));
+
+      final keyStrings = entries.map((e) => e.key).toSet();
+      expect(keyStrings, contains(assignmentCacheKeyToString(key1)));
+      expect(keyStrings, contains(assignmentCacheKeyToString(key2)));
+
+      final valueStrings = entries.map((e) => e.value).toSet();
+      expect(valueStrings, contains(assignmentCacheValueToString(value1)));
+      expect(valueStrings, contains(assignmentCacheValueToString(value2)));
+    });
+  });
+}


### PR DESCRIPTION
## capabilities

assignment logger - this is considered table stakes for SDK functionality

## testing

* new unit tests