### PR TITLE
infra: change base url to `https://fscdn.eppo.cloud` and route requests to `/edge/assignments`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,6 @@
 
 # Testing
 <!-- Describe how you tested your changes. Include any relevant details about test cases, environments, and results. --> 
+
+# Documentation
+<!-- Describe how the developer impact has been (or will be) documented. Link to PR or Ticket if applicable -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+# Motivation
+<!-- Describe the reason for this change. What problem does it solve or what feature does it add? -->
+
+# Changes
+<!-- List the changes made in this pull request. Be concise but specific. -->
+
+# Testing
+<!-- Describe how you tested your changes. Include any relevant details about test cases, environments, and results. --> 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.2
 
-- Updated base URL to `https://fscdn.eppo.cloud`
+- Updated base URL to `https://fscdn.eppo.cloud/edge`
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2
+
+- Updated base URL to `https://fscdn.eppo.cloud`
+
 ## 1.0.1
 
 - Improved pub.dev metadata to include correct repository and documentation

--- a/lib/src/api_client.dart
+++ b/lib/src/api_client.dart
@@ -31,7 +31,7 @@ class EppoApiClient {
     String? baseUrl,
     Duration? requestTimeout,
     EppoHttpClient? httpClient,
-  })  : baseUrl = baseUrl ?? precomputedBaseUrl,
+  })  : baseUrl = baseUrl ?? eppoBaseUrl,
         requestTimeout = requestTimeout ?? defaultRequestTimeout,
         _httpClient = httpClient ?? DefaultEppoHttpClient();
 

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,8 +1,8 @@
 /// Default base URL for Eppo API
-const String eppoBaseUrl = 'https://fscdn.eppo.cloud';
+const String eppoBaseUrl = 'https://fscdn.eppo.cloud/edge';
 
 /// Precomputed flags endpoint for fetching assignments
-const String precomputedFlagsEndpoint = '/edge/assignments';
+const String precomputedFlagsEndpoint = '/assignments';
 
 /// Default request timeout in milliseconds
 const Duration defaultRequestTimeout = Duration(seconds: 2);

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,8 +1,8 @@
 /// Default base URL for Eppo API
-const String precomputedBaseUrl = 'https://fs-edge-assignment.eppo.cloud';
+const String eppoBaseUrl = 'https://fscdn.eppo.cloud';
 
 /// Precomputed flags endpoint for fetching assignments
-const String precomputedFlagsEndpoint = '/assignments';
+const String precomputedFlagsEndpoint = '/edge/assignments';
 
 /// Default request timeout in milliseconds
 const Duration defaultRequestTimeout = Duration(seconds: 2);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: eppo
-version: 1.0.1
+version: 1.0.2
 description: Eppo SDK for Dart and Flutter applications
 homepage: https://geteppo.com
 repository: https://github.com/Eppo-exp/dart-sdk

--- a/test/configuration_wire_protocol_test.dart
+++ b/test/configuration_wire_protocol_test.dart
@@ -39,7 +39,7 @@ void main() {
       );
 
       // Verify the flags
-      expect(config.flags.length, equals(6));
+      expect(config.flags.length, equals(7));
 
       // Check the first flag (STRING type)
       final stringFlag = config.flags['41a27b85ebdd7b1a5ae367a1a240a214'];


### PR DESCRIPTION
# Motivation

Migrating routing to use the `fscdn.eppo.cloud` domain. The new canonical for this request is `fscdn.eppo.cloud/edge/assignments`

```
curl -v -X POST "https://qa-fscdn.eppo.cloud/edge/assignments?apiKey=XYZ" \
     -H "Content-Type: application/json" \
     -d '{
           "subject_key": "your_subject_key_value",
           "subject_attributes": {
            "numeric": {},
            "categorical": {}
           }
         }'

* Host qa-fscdn.eppo.cloud:443 was resolved.
* IPv6: (none)
* IPv4: 151.101.201.91
*   Trying 151.101.201.91:443...
* Connected to qa-fscdn.eppo.cloud (151.101.201.91) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256 / [blank] / UNDEF
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=fscdn.eppo.cloud
*  start date: Feb 12 14:52:46 2025 GMT
*  expire date: May 13 14:52:45 2025 GMT
*  subjectAltName: host "qa-fscdn.eppo.cloud" matched cert's "qa-fscdn.eppo.cloud"
*  issuer: C=US; O=Let's Encrypt; CN=R10
*  SSL certificate verify ok.
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://qa-fscdn.eppo.cloud/edge/assignments?apiKey=XYZ
* [HTTP/2] [1] [:method: POST]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: qa-fscdn.eppo.cloud]
* [HTTP/2] [1] [:path: /edge/assignments?apiKey=NC1BPkP7UOvKuObEY9ecf.ZWg9ZmsxMXh4LmUucWEuZXBwby5jbG91ZA]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [content-type: application/json]
* [HTTP/2] [1] [content-length: 169]
> POST /edge/assignments?apiKey=XYZ HTTP/2
> Host: qa-fscdn.eppo.cloud
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Type: application/json
> Content-Length: 169
>
* upload completely sent off: 169 bytes
< HTTP/2 200
< content-type: application/json
< access-control-allow-origin: *
< access-control-allow-methods: GET, POST, OPTIONS
< accept-ranges: bytes
< date: Thu, 13 Mar 2025 19:49:13 GMT
< via: 1.1 varnish
< x-served-by: cache-pao-kpao1770045-PAO, cache-pao-kpao1770045-PAO
< x-cache: MISS
< x-cache-hits: 0
< x-timer: S1741895353.872592,VS0,VE337
< content-length: 767
<
* Connection #0 to host qa-fscdn.eppo.cloud left intact
{"obfuscated":true,"format":"PRECOMPUTED","salt":"iKletj03CmQaRflU7ssGkg","createdAt":"2025-03-13T19:49:13.209439942Z","environment":{"name":"Production"},"flags":{"57a3f2e8ca7d1fc8960e9959d69ae472":{"variationType":"JSON","variationValue":"eyJodG1sLXRhZyI6ICJibGEifQ==","doLog":true,"allocationKey":"YWxsb2NhdGlvbi0xMTc=","variationKey":"Y29udHJvbA==","extraLogging":{}},"5f1211e09a7cba5e00c2c7e963b44a60":{"variationType":"STRING","variationValue":"YmFuZGl0MQ==","doLog":true,"allocationKey":"YWxsb2NhdGlvbi05Mw==","variationKey":"YmFuZGl0MQ==","extraLogging":{}},"59d6852375d3794ee31f48b5ead0e03a":{"variationType":"BOOLEAN","variationValue":"dHJ1ZQ==","doLog":true,"allocationKey":"YWxsb2NhdGlvbi05MQ==","variationKey":"dHJ1ZQ==","extraLogging":{}}},"bandits":{}}
```

## Changes

* Changes the base url to `https://fscdn.eppo.cloud`
* 

## Testing

The example program runs by fetching production configuration and it is success at returning non-default values:

```
Run dart example/example_precompute_client.dart *** github-subject

Example flag assignments:
-------------------------
logAssignment: dart-test-flag-string variant 2025-03-13 19:48:03.433068Z
string-flag: variant
logAssignment: dart-test-flag-boolean true 2025-03-13 19:48:03.435[7](https://github.com/Eppo-exp/dart-sdk/actions/runs/13843343448/job/38735949382#step:7:8)53Z
boolean-flag: true
logAssignment: dart-test-flag-integer 10 2025-03-13 19:4[8](https://github.com/Eppo-exp/dart-sdk/actions/runs/13843343448/job/38735949382#step:7:9):03.436522Z
integer-flag: 10
logAssignment: dart-test-flag-numeric 55.67 2025-03-13 1[9](https://github.com/Eppo-exp/dart-sdk/actions/runs/13843343448/job/38735949382#step:7:10):48:03.437785Z
numeric-flag: 55.67
logAssignment: dart-test-flag-json dart-ios 2025-03-13 19:48:03.438907Z
json-flag: {language: dart, platform: ios}
bandit-flag: action=null variation=default-bandit
```