### PR TITLE
infra: adds SdkKeyDecoder class

### DIFF
--- a/lib/src/sdk_key_decoder.dart
+++ b/lib/src/sdk_key_decoder.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'package:logging/logging.dart';
+
+/// A class for decoding SDK keys and extracting configuration hostname
+class SdkKeyDecoder {
+  static const String _paramName = 'ch';
+
+  static final Logger _logger = Logger('SdkKeyDecoder');
+
+  /// Decodes and returns the configuration hostname from the provided Eppo SDK key string.
+  /// If the SDK key doesn't contain the configuration hostname, or it's invalid, it returns null.
+  static String? decodeConfigurationHostname(String sdkKey) {
+    final parts = sdkKey.split('.');
+    if (parts.length < 2) return null;
+
+    final encodedPayload = parts[1];
+    if (encodedPayload.isEmpty) return null;
+
+    try {
+      final decodedPayload = utf8.decode(base64.decode(encodedPayload));
+      final params = Uri.splitQueryString(decodedPayload);
+      final hostname = params[_paramName];
+      if (hostname == null || hostname.isEmpty) return null;
+
+      if (!hostname.startsWith('http://') && !hostname.startsWith('https://')) {
+        // prefix hostname with https scheme if none present
+        return 'https://$hostname';
+      } else {
+        return hostname;
+      }
+    } catch (e) {
+      // Canonical Dart logging for `debug` level
+      _logger.fine('Error decoding configuration hostname: $e');
+      return null;
+    }
+  }
+}

--- a/test/sdk_key_decoder_test.dart
+++ b/test/sdk_key_decoder_test.dart
@@ -31,14 +31,14 @@ void main() {
     test('should decode configuration host when SDK key has both hosts', () {
       final hostname = SdkKeyDecoder.decodeConfigurationHostname(
         encodeSdkKey(
-          configHostname: '123456.e.testing.fscdn.eppo.cloud',
-          eventHostname: '123456.e.testing.eppo.cloud',
+          configHostname: 'https://123456.e.testing.fscdn.eppo.cloud',
+          eventHostname: 'https://123456.e.testing.eppo.cloud',
         ),
       );
       expect(hostname, equals('https://123456.e.testing.fscdn.eppo.cloud'));
     });
 
-    test('should add https://h prefix to hostname without scheme', () {
+    test('should add https prefix to hostname without scheme', () {
       final hostname = SdkKeyDecoder.decodeConfigurationHostname(
         encodeSdkKey(configHostname: '123456.e.testing.fscdn.eppo.cloud'),
       );

--- a/test/sdk_key_decoder_test.dart
+++ b/test/sdk_key_decoder_test.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:eppo/src/sdk_key_decoder.dart';
+
+String encodeSdkKey({String? configHostname, String? eventHostname}) {
+  final params = {
+    if (configHostname != null) 'ch': configHostname,
+    if (eventHostname != null) 'eh': eventHostname,
+  };
+  final queryString = Uri(queryParameters: params).query;
+  final encodedPayload = base64.encode(utf8.encode(queryString));
+  return 'zCsQuoHJxVPp895.$encodedPayload';
+}
+
+void main() {
+  group('SdkKeyDecoder', () {
+    test('should return null when SDK key has neither host', () {
+      final hostname = SdkKeyDecoder.decodeConfigurationHostname(
+        encodeSdkKey(),
+      );
+      expect(hostname, isNull);
+    });
+
+    test('should return null when SDK key has only event host', () {
+      final hostname = SdkKeyDecoder.decodeConfigurationHostname(
+        encodeSdkKey(eventHostname: '123456.e.testing.eppo.cloud'),
+      );
+      expect(hostname, isNull);
+    });
+
+    test('should decode configuration host when SDK key has both hosts', () {
+      final hostname = SdkKeyDecoder.decodeConfigurationHostname(
+        encodeSdkKey(
+          configHostname: '123456.e.testing.fscdn.eppo.cloud',
+          eventHostname: '123456.e.testing.eppo.cloud',
+        ),
+      );
+      expect(hostname, equals('https://123456.e.testing.fscdn.eppo.cloud'));
+    });
+
+    test('should add https://h prefix to hostname without scheme', () {
+      final hostname = SdkKeyDecoder.decodeConfigurationHostname(
+        encodeSdkKey(configHostname: '123456.e.testing.fscdn.eppo.cloud'),
+      );
+      expect(hostname, equals('https://123456.e.testing.fscdn.eppo.cloud'));
+    });
+  });
+}


### PR DESCRIPTION
## Motivation

* Support off-boarding clients - all requests today go to `fscdn.eppo.cloud/edge`. After server support for encoding the `ch` (configuration host) parameter into the SDK key (optionally along-side the `eh`, event logging host), clients with those SDK keys will make a request to `$unique-host$.fscdn.eppo.cloud/edge` which will enable DNS-level off-boarding

## Changes

Adds a `SdkKeyDecoder` class - implementation modeled on https://github.com/Eppo-exp/js-sdk-common/blob/main/src/events/sdk-key-decoder.ts

## Testing

Unit testing covering:

* legacy SDK keys with no host encoding
* SDK keys with `eh` 
* SDK keys coming in the future with both `eh` and `ch`
* Requiring `https`
