### PR TITLE
chore: tests should handle additional sdk test data created

### DIFF
--- a/test/configuration_wire_protocol_test.dart
+++ b/test/configuration_wire_protocol_test.dart
@@ -39,7 +39,7 @@ void main() {
       );
 
       // Verify the flags
-      expect(config.flags.length, equals(6));
+      expect(config.flags.length, greaterThanOrEqualTo(6));
 
       // Check the first flag (STRING type)
       final stringFlag = config.flags['41a27b85ebdd7b1a5ae367a1a240a214'];


### PR DESCRIPTION
A new flag was added to our test data which caused the test to fail on main but not my (older) PR branch.

I want to keep main passing but not be brittle.