### PR TITLE
Add support for multiple clients keyed by subject (FFL-556)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.0
+
+- Support for managing multiple user contexts (anonymous vs logged-in users)
+- `Eppo.forSubject()` returns `EppoPrecomputedClient` directly for simpler API
+- Added instance management methods: `removeSubject()` and `activeSubjects`
+
 ## 1.1.0
 
 - Added Customer-specific routing

--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ loggedInUser.getBooleanAssignment('feature-a', false);  // Different subject, di
 - Cache persists until `Eppo.removeSubject(subjectKey)` or `Eppo.reset()` is called
 - Each cache is isolated - removing one subject doesn't affect others
 
+**Immediate Availability:**
+- Client instances are stored in the registry immediately upon creation
+- Flag evaluations work right away (returning defaults until flag data loads)
+- Background flag fetching doesn't block access to the client
+
 **Memory Management:**
 ```dart
 // Clean up specific subject's cache when user logs out

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Handle transitions between anonymous and logged-in states:
 
 ```dart
 class UserSessionManager {
-  EppoInstance? _currentUserInstance;
+  EppoPrecomputedClient? _currentUserInstance;
   
   // When user is anonymous
   Future<void> initializeAnonymousUser(String sessionId) async {
@@ -205,7 +205,7 @@ class UserSessionManager {
   }
   
   // Get current user instance
-  EppoInstance? getCurrentUserInstance() => _currentUserInstance;
+  EppoPrecomputedClient? getCurrentUserInstance() => _currentUserInstance;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ The guide below will walk you through installing the SDK and implementing your f
 
 See [https://docs.geteppo.com/sdks/client-sdks/dart/quickstart/](https://docs.geteppo.com/sdks/client-sdks/dart/quickstart/) for detailed usage instructions.
 
+## Basic Usage (Singleton)
+
+For simple applications with a single user context:
+
 ```dart
 import 'package:eppo/eppo.dart';
 
@@ -15,26 +19,245 @@ await Eppo.initialize(
   'your-sdk-key',
   SubjectEvaluation(
     subject: Subject(
-      subjectKey: 'user-identifier'
-    )
-  )
+      subjectKey: 'user-123',
+      subjectAttributes: ContextAttributes(
+        categoricalAttributes: {
+          'country': 'US',
+          'device_type': 'mobile',
+          'subscription_plan': 'premium',
+        },
+        numericAttributes: {
+          'age': 28,
+          'account_age_days': 180,
+        },
+      ),
+    ),
+  ),
+  ClientConfiguration(),
 );
 
 // Make an assignment
 final String variation = Eppo.getStringAssignment(
-  'my-neat-feature',
-  'default-value',
+  'homepage-redesign',
+  'control',
 );
 
 // Render different components based on assignment
 switch(variation) {
-  case 'landing-page-a':
-    return renderLandingPageA();
-  case 'landing-page-b':
-    return renderLandingPageB();
+  case 'variant-a':
+    return renderHomepageVariantA();
+  case 'variant-b':
+    return renderHomepageVariantB();
   default:
-    return renderLandingPageC();
+    return renderHomepageControl();
 }
+```
+
+## Multi-Instance Usage (Recommended)
+
+For applications that need to handle both logged-out and logged-in users, or multiple user contexts:
+
+### Setup
+
+First, initialize the SDK with any user (this sets up shared configuration):
+
+```dart
+import 'package:eppo/eppo.dart';
+
+// Initialize SDK with initial user
+await Eppo.initialize(
+  'your-sdk-key',
+  SubjectEvaluation(
+    subject: Subject(subjectKey: 'initial-user'),
+  ),
+  ClientConfiguration(),
+);
+```
+
+### Logged-Out Users (Anonymous)
+
+For users who haven't logged in yet, use anonymous identifiers with basic device/session attributes:
+
+```dart
+// Create instance for anonymous user
+final anonymousUser = await Eppo.forSubject(
+  'anonymous-${generateSessionId()}', // e.g., 'anonymous-abc123def'
+  subjectAttributes: ContextAttributes(
+    categoricalAttributes: {
+      'user_type': 'anonymous',
+      'device_type': 'mobile',
+      'platform': 'ios',
+      'country': 'US',
+      'referrer_source': 'google',
+      'app_version': '2.1.0',
+    },
+    numericAttributes: {
+      'session_count': 1,
+      'days_since_install': 0,
+    },
+  ),
+);
+
+// Get feature flags for anonymous user
+bool showSignupBanner = anonymousUser.getBooleanAssignment('signup-banner', false);
+String onboardingFlow = anonymousUser.getStringAssignment('onboarding-flow', 'standard');
+int maxFreeArticles = anonymousUser.getIntegerAssignment('free-article-limit', 3);
+```
+
+### Logged-In Users
+
+For authenticated users, use their user ID with rich user attributes:
+
+```dart
+// Create instance for authenticated user
+final loggedInUser = await Eppo.forSubject(
+  'user-${userId}', // e.g., 'user-12345'
+  subjectAttributes: ContextAttributes(
+    categoricalAttributes: {
+      'user_type': 'authenticated',
+      'subscription_plan': 'premium',
+      'user_segment': 'power_user',
+      'country': 'US',
+      'device_type': 'mobile',
+      'platform': 'ios',
+      'registration_source': 'organic',
+      'preferred_language': 'en',
+    },
+    numericAttributes: {
+      'age': 32,
+      'account_age_days': 245,
+      'lifetime_value': 299.99,
+      'monthly_sessions': 18,
+      'articles_read_last_30_days': 45,
+    },
+  ),
+);
+
+// Get feature flags for authenticated user
+bool showPremiumFeatures = loggedInUser.getBooleanAssignment('premium-features', false);
+String dashboardLayout = loggedInUser.getStringAssignment('dashboard-layout', 'classic');
+double discountRate = loggedInUser.getNumericAssignment('loyalty-discount', 0.0);
+
+// Get personalized recommendations using bandits
+BanditEvaluation recommendation = loggedInUser.getBanditAction('content-recommendations', 'trending');
+String recommendationType = recommendation.variation;
+String? specificContent = recommendation.action;
+```
+
+### User State Transitions
+
+Handle transitions between anonymous and logged-in states:
+
+```dart
+class UserSessionManager {
+  EppoInstance? _currentUserInstance;
+  
+  // When user is anonymous
+  Future<void> initializeAnonymousUser(String sessionId) async {
+    _currentUserInstance = await Eppo.forSubject(
+      'anonymous-$sessionId',
+      subjectAttributes: ContextAttributes(
+        categoricalAttributes: {
+          'user_type': 'anonymous',
+          'device_type': Platform.isIOS ? 'ios' : 'android',
+          'app_version': await getAppVersion(),
+        },
+        numericAttributes: {
+          'session_count': await getSessionCount(),
+        },
+      ),
+    );
+  }
+  
+  // When user logs in
+  Future<void> loginUser(String userId, Map<String, dynamic> userProfile) async {
+    // Clean up anonymous user instance
+    if (_currentUserInstance != null) {
+      Eppo.removeSubject('anonymous-${getCurrentSessionId()}');
+    }
+    
+    // Create authenticated user instance
+    _currentUserInstance = await Eppo.forSubject(
+      'user-$userId',
+      subjectAttributes: ContextAttributes(
+        categoricalAttributes: {
+          'user_type': 'authenticated',
+          'subscription_plan': userProfile['plan'] ?? 'free',
+          'user_segment': userProfile['segment'] ?? 'regular',
+          'country': userProfile['country'] ?? 'unknown',
+        },
+        numericAttributes: {
+          'age': userProfile['age'] ?? 0,
+          'account_age_days': calculateAccountAge(userProfile['created_at']),
+          'lifetime_value': userProfile['ltv'] ?? 0.0,
+        },
+      ),
+    );
+  }
+  
+  // When user logs out
+  Future<void> logoutUser() async {
+    if (_currentUserInstance != null) {
+      Eppo.removeSubject('user-${getCurrentUserId()}');
+      // Optionally initialize new anonymous session
+      await initializeAnonymousUser(generateNewSessionId());
+    }
+  }
+  
+  // Get current user instance
+  EppoInstance? getCurrentUserInstance() => _currentUserInstance;
+}
+```
+
+### Caching and Performance
+
+Each subject instance maintains its own isolated cache for flag assignments and bandit actions. This provides several benefits:
+
+- **Isolation**: Anonymous and logged-in users have separate caches, preventing cross-contamination
+- **Deduplication**: Repeated flag evaluations for the same subject won't generate duplicate assignment logs
+- **Performance**: Flag values are cached after first evaluation, reducing computation overhead
+
+```dart
+// Each subject gets its own cache
+final anonymousUser = await Eppo.forSubject('anonymous-123');
+final loggedInUser = await Eppo.forSubject('user-456');
+
+// These calls will be cached separately per subject
+anonymousUser.getBooleanAssignment('feature-a', false); // First call: evaluated + cached
+anonymousUser.getBooleanAssignment('feature-a', false); // Second call: served from cache
+
+loggedInUser.getBooleanAssignment('feature-a', false);  // Different subject, different cache
+```
+
+**Cache Lifecycle:**
+- Cache is created when `Eppo.forSubject()` is first called for a subject
+- Cache persists until `Eppo.removeSubject(subjectKey)` or `Eppo.reset()` is called
+- Each cache is isolated - removing one subject doesn't affect others
+
+**Memory Management:**
+```dart
+// Clean up specific subject's cache when user logs out
+Eppo.removeSubject('user-12345'); // Frees cache for this subject only
+
+// Clean up anonymous user cache after login
+Eppo.removeSubject('anonymous-session-abc'); 
+
+// Clean up all caches (app restart, complete reset)
+Eppo.reset(); // Clears all subject caches and instances
+```
+
+### Instance Management
+
+```dart
+// Check active instances
+List<String> activeUsers = Eppo.activeSubjects;
+print('Active instances: $activeUsers');
+
+// Clean up specific instance (removes cache and client)
+Eppo.removeSubject('user-12345');
+
+// Clean up all instances (app restart, etc.)
+Eppo.reset();
 ```
 
 ## Installation

--- a/example/README.md
+++ b/example/README.md
@@ -200,18 +200,26 @@ Final active subjects: [user-123, user-456, user-789]
 ```dart
 // Create instances for different users
 final anonymousUser = await Eppo.forSubject(
-  'anonymous-session-123',
-  subjectAttributes: ContextAttributes(
-    categoricalAttributes: {'user_type': 'anonymous'},
-    numericAttributes: {'session_count': 1},
+  SubjectEvaluation(
+    subject: Subject(
+      subjectKey: 'anonymous-session-123',
+      subjectAttributes: ContextAttributes(
+        categoricalAttributes: {'user_type': 'anonymous'},
+        numericAttributes: {'session_count': 1},
+      ),
+    ),
   ),
 );
 
 final loggedInUser = await Eppo.forSubject(
-  'user-456',
-  subjectAttributes: ContextAttributes(
-    categoricalAttributes: {'user_type': 'authenticated', 'plan': 'premium'},
-    numericAttributes: {'age': 30, 'account_age_days': 180},
+  SubjectEvaluation(
+    subject: Subject(
+      subjectKey: 'user-456',
+      subjectAttributes: ContextAttributes(
+        categoricalAttributes: {'user_type': 'authenticated', 'plan': 'premium'},
+        numericAttributes: {'age': 30, 'account_age_days': 180},
+      ),
+    ),
   ),
 );
 

--- a/example/README.md
+++ b/example/README.md
@@ -143,24 +143,24 @@ print('bandit-flag: action=${banditValue.action} variation=${banditValue.variati
 
 ## Example Output Structure
 
-When run successfully, you'll see a comprehensive demonstration organized into 7 parts:
+When run successfully, you'll see a comprehensive demonstration:
 
 ```
-🚀 Eppo SDK Multi-Instance Example
-===================================
+Eppo SDK Multi-Instance Example
+=================================
 
-📱 Part 1: Singleton API
--------------------------
+1️⃣ Singleton API
+----------------
 ✅ Initialized SDK for logged-in user: user-123
    Premium feature enabled: true
 
-👥 Part 2: Multi-Instance API
-------------------------------
+2️⃣ Multi-Instance API
+---------------------
 ✅ Created anonymous user instance
 ✅ Created second user instance
 
-🔍 Part 3: Flag Evaluations Per User
-------------------------------------
+3️⃣ Flag Evaluations Per User
+----------------------------
 Anonymous user flags:
    Premium feature: false
    Show signup banner: false
@@ -169,27 +169,27 @@ Second user flags:
    Premium feature: false
    Show signup banner: false
 
-🔗 Part 4: API Coexistence
---------------------------
+API Coexistence:
+----------------
 Singleton API result: true
 Multi-instance API (same subject): true
-Results match: true
+✅ Results match: true
 
-📊 Part 5: Instance Management
-------------------------------
+Instance Management:
+-------------------
 Active subjects: [user-123, anonymous-session-abc123, user-456]
 Total instances: 3
 
 Cleaning up anonymous user...
 Active subjects after cleanup: [user-123, user-456]
 
-🔄 Part 6: User State Transition
----------------------------------
+User State Transition:
+---------------------
 Simulating anonymous → logged-in user transition...
 Before login - signup banner: false
 After login - premium feature: true
 
-✨ Example completed successfully!
+✅ Example completed successfully!
 Final active subjects: [user-123, user-456, user-789]
 ```
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,14 +1,18 @@
 # Eppo Feature Flagging SDK Example
 
-This example demonstrates how to use the Eppo SDK for feature flagging and experimentation in a Dart application.
+This example demonstrates how to use the Eppo SDK for feature flagging and experimentation in a Dart application, showcasing both the traditional singleton API and the new multi-instance API.
 
 ## What This Example Shows
 
-- How to initialize the Eppo SDK
-- How to create and configure a subject with attributes
-- How to evaluate different types of feature flags (string, boolean, integer, numeric, JSON)
-- How to use bandit actions
-- How to implement a custom assignment logger
+- **Singleton API**: Traditional single-user SDK usage
+- **Multi-Instance API**: Managing multiple user contexts (anonymous vs. logged-in users)
+- **User State Transitions**: Handling anonymous → logged-in user flows
+- **API Coexistence**: How both APIs work together seamlessly
+- **Instance Management**: Creating, using, and cleaning up user instances
+- **Different User Types**: Anonymous users, free users, premium users with different attributes
+- **Feature Flag Types**: String, boolean, integer, numeric, JSON flags
+- **Bandit Actions**: Personalized recommendations and content selection
+- **Custom Assignment Logger**: Tracking flag assignments for analytics
 
 ## Running the Example
 
@@ -137,19 +141,96 @@ final banditValue = Eppo.getBanditAction('update-highlights-bandit', 'default-ba
 print('bandit-flag: action=${banditValue.action} variation=${banditValue.variation}');
 ```
 
-## Expected Output
+## Example Output Structure
 
-When run successfully, you should see output similar to:
+When run successfully, you'll see a comprehensive demonstration organized into 7 parts:
 
 ```
-Example flag assignments:
+🚀 Eppo SDK Multi-Instance Example
+===================================
+
+📱 Part 1: Singleton API
 -------------------------
-string-flag: value-from-eppo
-boolean-flag: true
-integer-flag: 42
-numeric-flag: 3.14
-json-flag: {key: value, nested: {property: example}}
-bandit-flag: action=recommended-action variation=variation-1
+✅ Initialized SDK for logged-in user: user-123
+   Premium feature enabled: true
+
+👥 Part 2: Multi-Instance API
+------------------------------
+✅ Created anonymous user instance
+✅ Created second user instance
+
+🔍 Part 3: Flag Evaluations Per User
+------------------------------------
+Anonymous user flags:
+   Premium feature: false
+   Show signup banner: false
+
+Second user flags:
+   Premium feature: false
+   Show signup banner: false
+
+🔗 Part 4: API Coexistence
+--------------------------
+Singleton API result: true
+Multi-instance API (same subject): true
+Results match: true
+
+📊 Part 5: Instance Management
+------------------------------
+Active subjects: [user-123, anonymous-session-abc123, user-456]
+Total instances: 3
+
+Cleaning up anonymous user...
+Active subjects after cleanup: [user-123, user-456]
+
+🔄 Part 6: User State Transition
+---------------------------------
+Simulating anonymous → logged-in user transition...
+Before login - signup banner: false
+After login - premium feature: true
+
+✨ Example completed successfully!
+Final active subjects: [user-123, user-456, user-789]
+```
+
+## Key API Additions
+
+### Multi-Instance Usage
+
+```dart
+// Create instances for different users
+final anonymousUser = await Eppo.forSubject(
+  'anonymous-session-123',
+  subjectAttributes: ContextAttributes(
+    categoricalAttributes: {'user_type': 'anonymous'},
+    numericAttributes: {'session_count': 1},
+  ),
+);
+
+final loggedInUser = await Eppo.forSubject(
+  'user-456',
+  subjectAttributes: ContextAttributes(
+    categoricalAttributes: {'user_type': 'authenticated', 'plan': 'premium'},
+    numericAttributes: {'age': 30, 'account_age_days': 180},
+  ),
+);
+
+// Use per-user flag evaluations
+bool showSignup = anonymousUser.getBooleanAssignment('signup-banner', false);
+bool premiumFeature = loggedInUser.getBooleanAssignment('premium-feature', false);
+```
+
+### Instance Management
+
+```dart
+// Check active instances
+List<String> activeUsers = Eppo.activeSubjects;
+
+// Clean up when user logs out
+Eppo.removeSubject('anonymous-session-123');
+
+// Reset all instances
+Eppo.reset();
 ```
 
 ## Further Reading

--- a/example/main.dart
+++ b/example/main.dart
@@ -72,7 +72,7 @@ void main(List<String> args) async {
   print('---------------------');
 
   // Create instance for anonymous user
-  final anonymousUser = await Eppo.forSubject(
+  final EppoPrecomputedClient anonymousUser = await Eppo.forSubject(
     'anonymous-session-abc123',
     subjectAttributes: ContextAttributes(
       categoricalAttributes: {

--- a/example/main.dart
+++ b/example/main.dart
@@ -39,12 +39,12 @@ void main(List<String> args) async {
     assignmentLogger: MyAssignmentLogger(),
   );
 
-  print('🚀 Eppo SDK Multi-Instance Example');
-  print('===================================');
+  print('Eppo SDK Multi-Instance Example');
+  print('=================================');
 
-  // === PART 1: SINGLETON API (Traditional Usage) ===
-  print('\n📱 Part 1: Singleton API');
-  print('-------------------------');
+  // === 1️⃣ SINGLETON API (Traditional Usage) ===
+  print('\n1️⃣ Singleton API');
+  print('----------------');
   
   // Initialize with a logged-in user
   final loggedInUser = Subject(
@@ -67,9 +67,9 @@ void main(List<String> args) async {
   final premiumFeature = Eppo.getBooleanAssignment('premium-feature', false);
   print('   Premium feature enabled: $premiumFeature');
 
-  // === PART 2: MULTI-INSTANCE API ===
-  print('\n👥 Part 2: Multi-Instance API');
-  print('------------------------------');
+  // === 2️⃣ MULTI-INSTANCE API ===
+  print('\n2️⃣ Multi-Instance API');
+  print('---------------------');
 
   // Create instance for anonymous user
   final anonymousUser = await Eppo.forSubject(
@@ -104,9 +104,9 @@ void main(List<String> args) async {
   );
   print('✅ Created second user instance');
 
-  // === PART 3: DEMONSTRATE DIFFERENT EVALUATIONS ===
-  print('\n🔍 Part 3: Flag Evaluations Per User');
-  print('------------------------------------');
+  // === 3️⃣ FLAG EVALUATIONS PER USER ===
+  print('\n3️⃣ Flag Evaluations Per User');
+  print('----------------------------');
 
   // Anonymous user evaluations
   final anonPremium = anonymousUser.getBooleanAssignment('premium-feature', false);
@@ -124,9 +124,9 @@ void main(List<String> args) async {
   print('   Premium feature: $otherPremium');
   print('   Show signup banner: $otherSignupBanner');
 
-  // === PART 4: DEMONSTRATE SINGLETON + MULTI-INSTANCE COEXISTENCE ===
-  print('\n🔗 Part 4: API Coexistence');
-  print('--------------------------');
+  // === API COEXISTENCE ===
+  print('\nAPI Coexistence:');
+  print('----------------');
 
   // Singleton API still works
   final singletonResult = Eppo.getBooleanAssignment('premium-feature', false);
@@ -136,11 +136,11 @@ void main(List<String> args) async {
   final sameAssingleton = await Eppo.forSubject(subjectKey);
   final instanceResult = sameAssingleton.getBooleanAssignment('premium-feature', false);
   print('Multi-instance API (same subject): $instanceResult');
-  print('Results match: ${singletonResult == instanceResult}');
+  print('✅ Results match: ${singletonResult == instanceResult}');
 
-  // === PART 5: INSTANCE MANAGEMENT ===
-  print('\n📊 Part 5: Instance Management');
-  print('------------------------------');
+  // === INSTANCE MANAGEMENT ===
+  print('\nInstance Management:');
+  print('-------------------');
 
   print('Active subjects: ${Eppo.activeSubjects}');
   print('Total instances: ${Eppo.activeSubjects.length}');
@@ -150,9 +150,9 @@ void main(List<String> args) async {
   Eppo.removeSubject('anonymous-session-abc123');
   print('Active subjects after cleanup: ${Eppo.activeSubjects}');
 
-  // === PART 6: USER STATE TRANSITION EXAMPLE ===
-  print('\n🔄 Part 6: User State Transition');
-  print('---------------------------------');
+  // === USER STATE TRANSITION ===
+  print('\nUser State Transition:');
+  print('---------------------');
 
   // Simulate user login flow
   print('Simulating anonymous → logged-in user transition...');
@@ -179,7 +179,7 @@ void main(List<String> args) async {
   final afterLogin = newLoggedInUser.getBooleanAssignment('premium-feature', false);
   print('After login - premium feature: $afterLogin');
 
-  print('\n✨ Example completed successfully!');
+  print('\n✅ Example completed successfully!');
   print('Final active subjects: ${Eppo.activeSubjects}');
   
   exit(0);

--- a/example/main.dart
+++ b/example/main.dart
@@ -11,7 +11,10 @@ class MyAssignmentLogger extends AssignmentLogger {
 }
 
 /// This example demonstrates how to use the Eppo SDK to fetch and evaluate
-/// feature flags and bandit actions for a given subject.
+/// feature flags and bandit actions for multiple subjects.
+///
+/// Shows both the singleton API and the new multi-instance API for handling
+/// anonymous users, logged-in users, and user state transitions.
 ///
 /// The SDK key is required and should be a valid Eppo SDK key.
 /// The subject key is optional and defaults to 'user-123'.
@@ -22,7 +25,7 @@ void main(List<String> args) async {
   // Check for SDK key in arguments
   if (args.isEmpty) {
     print(
-      'Usage: dart example/example_precompute_client.dart <sdk-key> <subject-key>',
+      'Usage: dart example/main.dart <sdk-key> [subject-key]',
     );
     exit(1);
   }
@@ -30,51 +33,154 @@ void main(List<String> args) async {
   final sdkKey = args[0];
   final subjectKey = args.length > 1 ? args[1] : 'user-123';
 
-  // Create subject with attributes
-  final subject = Subject(
-    subjectKey: subjectKey,
-    subjectAttributes: ContextAttributes(
-      categoricalAttributes: {'country': 'US', 'device': 'mobile'},
-      numericAttributes: {'age': 30, 'visits': 5},
-    ),
-  );
-  final subjectEvaluation = SubjectEvaluation(subject: subject);
-
-  // Create SDK options
+  // Create SDK configuration
   final clientConfiguration = ClientConfiguration(
     sdkPlatform: SdkPlatform.dart,
     assignmentLogger: MyAssignmentLogger(),
   );
 
-  // Initialize the SDK
-  await Eppo.initialize(sdkKey, subjectEvaluation, clientConfiguration);
+  print('🚀 Eppo SDK Multi-Instance Example');
+  print('===================================');
 
-  // Print some example assignments
-  print('\nExample flag assignments:');
+  // === PART 1: SINGLETON API (Traditional Usage) ===
+  print('\n📱 Part 1: Singleton API');
   print('-------------------------');
+  
+  // Initialize with a logged-in user
+  final loggedInUser = Subject(
+    subjectKey: subjectKey,
+    subjectAttributes: ContextAttributes(
+      categoricalAttributes: {
+        'user_type': 'authenticated',
+        'subscription_plan': 'premium',
+        'country': 'US',
+        'device': 'mobile'
+      },
+      numericAttributes: {'age': 30, 'account_age_days': 180},
+    ),
+  );
+  
+  await Eppo.initialize(sdkKey, SubjectEvaluation(subject: loggedInUser), clientConfiguration);
+  print('✅ Initialized SDK for logged-in user: $subjectKey');
 
-  // Get precomputed assignments
-  final stringValue =
-      Eppo.getStringAssignment('dart-test-flag-string', 'default-string');
-  print('string-flag: $stringValue');
+  // Use singleton methods
+  final premiumFeature = Eppo.getBooleanAssignment('premium-feature', false);
+  print('   Premium feature enabled: $premiumFeature');
 
-  final boolValue = Eppo.getBooleanAssignment('dart-test-flag-boolean', false);
-  print('boolean-flag: $boolValue');
+  // === PART 2: MULTI-INSTANCE API ===
+  print('\n👥 Part 2: Multi-Instance API');
+  print('------------------------------');
 
-  final intValue = Eppo.getIntegerAssignment('dart-test-flag-integer', 0);
-  print('integer-flag: $intValue');
+  // Create instance for anonymous user
+  final anonymousUser = await Eppo.forSubject(
+    'anonymous-session-abc123',
+    subjectAttributes: ContextAttributes(
+      categoricalAttributes: {
+        'user_type': 'anonymous',
+        'device': 'mobile',
+        'platform': 'dart',
+        'referrer_source': 'organic',
+      },
+      numericAttributes: {
+        'session_count': 1,
+        'days_since_install': 0,
+      },
+    ),
+  );
+  print('✅ Created anonymous user instance');
 
-  final numValue = Eppo.getNumericAssignment('dart-test-flag-numeric', 0.0);
-  print('numeric-flag: $numValue');
+  // Create instance for different logged-in user
+  final otherUser = await Eppo.forSubject(
+    'user-456',
+    subjectAttributes: ContextAttributes(
+      categoricalAttributes: {
+        'user_type': 'authenticated',
+        'subscription_plan': 'free',
+        'country': 'CA',
+        'device': 'desktop',
+      },
+      numericAttributes: {'age': 25, 'account_age_days': 45},
+    ),
+  );
+  print('✅ Created second user instance');
 
-  final jsonValue = Eppo.getJSONAssignment('dart-test-flag-json', {});
-  print('json-flag: $jsonValue');
+  // === PART 3: DEMONSTRATE DIFFERENT EVALUATIONS ===
+  print('\n🔍 Part 3: Flag Evaluations Per User');
+  print('------------------------------------');
 
-  // Get precomputed bandit assignments
-  final banditValue =
-      Eppo.getBanditAction('update-highlights-bandit', 'default-bandit');
-  print(
-      'bandit-flag: action=${banditValue.action} variation=${banditValue.variation}');
+  // Anonymous user evaluations
+  final anonPremium = anonymousUser.getBooleanAssignment('premium-feature', false);
+  final anonSignupBanner = anonymousUser.getBooleanAssignment('signup-banner', false);
+  
+  print('Anonymous user flags:');
+  print('   Premium feature: $anonPremium');
+  print('   Show signup banner: $anonSignupBanner');
 
+  // Other user evaluations  
+  final otherPremium = otherUser.getBooleanAssignment('premium-feature', false);
+  final otherSignupBanner = otherUser.getBooleanAssignment('signup-banner', false);
+
+  print('\nSecond user flags:');
+  print('   Premium feature: $otherPremium');
+  print('   Show signup banner: $otherSignupBanner');
+
+  // === PART 4: DEMONSTRATE SINGLETON + MULTI-INSTANCE COEXISTENCE ===
+  print('\n🔗 Part 4: API Coexistence');
+  print('--------------------------');
+
+  // Singleton API still works
+  final singletonResult = Eppo.getBooleanAssignment('premium-feature', false);
+  print('Singleton API result: $singletonResult');
+
+  // Same subject as singleton returns same client
+  final sameAssingleton = await Eppo.forSubject(subjectKey);
+  final instanceResult = sameAssingleton.getBooleanAssignment('premium-feature', false);
+  print('Multi-instance API (same subject): $instanceResult');
+  print('Results match: ${singletonResult == instanceResult}');
+
+  // === PART 5: INSTANCE MANAGEMENT ===
+  print('\n📊 Part 5: Instance Management');
+  print('------------------------------');
+
+  print('Active subjects: ${Eppo.activeSubjects}');
+  print('Total instances: ${Eppo.activeSubjects.length}');
+
+  // Cleanup example
+  print('\nCleaning up anonymous user...');
+  Eppo.removeSubject('anonymous-session-abc123');
+  print('Active subjects after cleanup: ${Eppo.activeSubjects}');
+
+  // === PART 6: USER STATE TRANSITION EXAMPLE ===
+  print('\n🔄 Part 6: User State Transition');
+  print('---------------------------------');
+
+  // Simulate user login flow
+  print('Simulating anonymous → logged-in user transition...');
+  
+  // 1. Start with anonymous user
+  final tempAnonymous = await Eppo.forSubject('temp-anonymous-xyz');
+  final beforeLogin = tempAnonymous.getBooleanAssignment('signup-banner', false);
+  print('Before login - signup banner: $beforeLogin');
+
+  // 2. User logs in - clean up anonymous, create authenticated
+  Eppo.removeSubject('temp-anonymous-xyz');
+  final newLoggedInUser = await Eppo.forSubject(
+    'user-789',
+    subjectAttributes: ContextAttributes(
+      categoricalAttributes: {
+        'user_type': 'authenticated',
+        'subscription_plan': 'premium',
+        'country': 'US',
+      },
+      numericAttributes: {'age': 28, 'account_age_days': 1}, // New user
+    ),
+  );
+  
+  final afterLogin = newLoggedInUser.getBooleanAssignment('premium-feature', false);
+  print('After login - premium feature: $afterLogin');
+
+  print('\n✨ Example completed successfully!');
+  print('Final active subjects: ${Eppo.activeSubjects}');
+  
   exit(0);
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -73,33 +73,41 @@ void main(List<String> args) async {
 
   // Create instance for anonymous user
   final EppoPrecomputedClient anonymousUser = await Eppo.forSubject(
-    'anonymous-session-abc123',
-    subjectAttributes: ContextAttributes(
-      categoricalAttributes: {
-        'user_type': 'anonymous',
-        'device': 'mobile',
-        'platform': 'dart',
-        'referrer_source': 'organic',
-      },
-      numericAttributes: {
-        'session_count': 1,
-        'days_since_install': 0,
-      },
+    SubjectEvaluation(
+      subject: Subject(
+        subjectKey: 'anonymous-session-abc123',
+        subjectAttributes: ContextAttributes(
+          categoricalAttributes: {
+            'user_type': 'anonymous',
+            'device': 'mobile',
+            'platform': 'dart',
+            'referrer_source': 'organic',
+          },
+          numericAttributes: {
+            'session_count': 1,
+            'days_since_install': 0,
+          },
+        ),
+      ),
     ),
   );
   print('✅ Created anonymous user instance');
 
   // Create instance for different logged-in user
   final otherUser = await Eppo.forSubject(
-    'user-456',
-    subjectAttributes: ContextAttributes(
-      categoricalAttributes: {
-        'user_type': 'authenticated',
-        'subscription_plan': 'free',
-        'country': 'CA',
-        'device': 'desktop',
-      },
-      numericAttributes: {'age': 25, 'account_age_days': 45},
+    SubjectEvaluation(
+      subject: Subject(
+        subjectKey: 'user-456',
+        subjectAttributes: ContextAttributes(
+          categoricalAttributes: {
+            'user_type': 'authenticated',
+            'subscription_plan': 'free',
+            'country': 'CA',
+            'device': 'desktop',
+          },
+          numericAttributes: {'age': 25, 'account_age_days': 45},
+        ),
+      ),
     ),
   );
   print('✅ Created second user instance');
@@ -133,7 +141,9 @@ void main(List<String> args) async {
   print('Singleton API result: $singletonResult');
 
   // Same subject as singleton returns same client
-  final sameAssingleton = await Eppo.forSubject(subjectKey);
+  final sameAssingleton = await Eppo.forSubject(
+    SubjectEvaluation(subject: Subject(subjectKey: subjectKey)),
+  );
   final instanceResult = sameAssingleton.getBooleanAssignment('premium-feature', false);
   print('Multi-instance API (same subject): $instanceResult');
   print('✅ Results match: ${singletonResult == instanceResult}');
@@ -158,21 +168,27 @@ void main(List<String> args) async {
   print('Simulating anonymous → logged-in user transition...');
   
   // 1. Start with anonymous user
-  final tempAnonymous = await Eppo.forSubject('temp-anonymous-xyz');
+  final tempAnonymous = await Eppo.forSubject(
+    SubjectEvaluation(subject: Subject(subjectKey: 'temp-anonymous-xyz')),
+  );
   final beforeLogin = tempAnonymous.getBooleanAssignment('signup-banner', false);
   print('Before login - signup banner: $beforeLogin');
 
   // 2. User logs in - clean up anonymous, create authenticated
   Eppo.removeSubject('temp-anonymous-xyz');
   final newLoggedInUser = await Eppo.forSubject(
-    'user-789',
-    subjectAttributes: ContextAttributes(
-      categoricalAttributes: {
-        'user_type': 'authenticated',
-        'subscription_plan': 'premium',
-        'country': 'US',
-      },
-      numericAttributes: {'age': 28, 'account_age_days': 1}, // New user
+    SubjectEvaluation(
+      subject: Subject(
+        subjectKey: 'user-789',
+        subjectAttributes: ContextAttributes(
+          categoricalAttributes: {
+            'user_type': 'authenticated',
+            'subscription_plan': 'premium',
+            'country': 'US',
+          },
+          numericAttributes: {'age': 28, 'account_age_days': 1}, // New user
+        ),
+      ),
     ),
   );
   

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: eppo
-version: 1.1.0
+version: 1.2.0
 description: Eppo is a composable next-generation feature flagging and experimentation platform focused on tightly integrating with your existing tech stack.
 homepage: https://geteppo.com
 repository: https://github.com/Eppo-exp/dart-sdk

--- a/test/multi_instance_test.dart
+++ b/test/multi_instance_test.dart
@@ -27,7 +27,7 @@ void main() {
 
       // Should not throw
       final instance = await Eppo.forSubject('test-user');
-      expect(instance, isA<EppoInstance>());
+      expect(instance, isA<EppoPrecomputedClient>());
     });
 
     test('multiple subjects can have separate instances', () async {
@@ -43,8 +43,8 @@ void main() {
       final user1 = await Eppo.forSubject('user-1');
       final user2 = await Eppo.forSubject('user-2');
 
-      expect(user1, isA<EppoInstance>());
-      expect(user2, isA<EppoInstance>());
+      expect(user1, isA<EppoPrecomputedClient>());
+      expect(user2, isA<EppoPrecomputedClient>());
       expect(Eppo.activeSubjects.length, 3); // initial-user + user-1 + user-2
       expect(Eppo.activeSubjects, contains('initial-user'));
       expect(Eppo.activeSubjects, contains('user-1'));
@@ -105,7 +105,7 @@ void main() {
       expect(Eppo.activeSubjects.length, 0);
     });
 
-    test('EppoInstance provides all flag evaluation methods', () async {
+    test('EppoPrecomputedClient provides all flag evaluation methods', () async {
       // Initialize the SDK first
       await Eppo.initialize(
         'test-sdk-key',
@@ -144,7 +144,7 @@ void main() {
       
       // Getting an instance for the same subject should return the same client
       final sameSubjectInstance = await Eppo.forSubject('singleton-user');
-      expect(sameSubjectInstance, isA<EppoInstance>());
+      expect(sameSubjectInstance, isA<EppoPrecomputedClient>());
       
       // Should only have one instance total
       expect(Eppo.activeSubjects.length, 1);
@@ -167,7 +167,7 @@ void main() {
       );
 
       // Make multiple concurrent calls for the same subject
-      final futures = <Future<EppoInstance>>[];
+      final futures = <Future<EppoPrecomputedClient>>[];
       for (int i = 0; i < 5; i++) {
         futures.add(Eppo.forSubject('concurrent-user'));
       }
@@ -183,7 +183,7 @@ void main() {
       // All returned instances should be for the same underlying client
       expect(instances.length, 5);
       for (final instance in instances) {
-        expect(instance, isA<EppoInstance>());
+        expect(instance, isA<EppoPrecomputedClient>());
       }
     });
 
@@ -210,7 +210,7 @@ void main() {
       
       // Complete the creation
       final instance = await futureInstance;
-      expect(instance, isA<EppoInstance>());
+      expect(instance, isA<EppoPrecomputedClient>());
       
       // Should still be there after completion
       expect(Eppo.activeSubjects, contains('new-user'));
@@ -233,7 +233,7 @@ void main() {
 
       // 3. Use forSubject with same subject key as singleton
       final sameUserInstance = await Eppo.forSubject('user-123');
-      expect(sameUserInstance, isA<EppoInstance>());
+      expect(sameUserInstance, isA<EppoPrecomputedClient>());
       
       // Should return same results as singleton (same underlying client)
       String instanceResult = sameUserInstance.getStringAssignment('test-flag', 'default');
@@ -241,7 +241,7 @@ void main() {
 
       // 4. Use forSubject with different subject key
       final otherUserInstance = await Eppo.forSubject('user-456');
-      expect(otherUserInstance, isA<EppoInstance>());
+      expect(otherUserInstance, isA<EppoPrecomputedClient>());
 
       // 5. Verify storage
       expect(Eppo.activeSubjects.length, 2);

--- a/test/multi_instance_test.dart
+++ b/test/multi_instance_test.dart
@@ -1,0 +1,129 @@
+import 'package:test/test.dart';
+import '../lib/eppo.dart';
+
+void main() {
+  group('Multi-Instance Support', () {
+    setUp(() {
+      // Reset before each test
+      Eppo.reset();
+    });
+
+    test('forSubject throws StateError when not initialized', () async {
+      expect(
+        () async => await Eppo.forSubject('test-user'),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('forSubject works after initialization', () async {
+      // Initialize the SDK first
+      await Eppo.initialize(
+        'test-sdk-key',
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'initial-user'),
+        ),
+        ClientConfiguration(),
+      );
+
+      // Should not throw
+      final instance = await Eppo.forSubject('test-user');
+      expect(instance, isA<EppoInstance>());
+    });
+
+    test('multiple subjects can have separate instances', () async {
+      // Initialize the SDK first
+      await Eppo.initialize(
+        'test-sdk-key',
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'initial-user'),
+        ),
+        ClientConfiguration(),
+      );
+
+      final user1 = await Eppo.forSubject('user-1');
+      final user2 = await Eppo.forSubject('user-2');
+
+      expect(user1, isA<EppoInstance>());
+      expect(user2, isA<EppoInstance>());
+      expect(Eppo.activeSubjects.length, 2);
+      expect(Eppo.activeSubjects, contains('user-1'));
+      expect(Eppo.activeSubjects, contains('user-2'));
+    });
+
+    test('same subject returns same instance', () async {
+      // Initialize the SDK first
+      await Eppo.initialize(
+        'test-sdk-key',
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'initial-user'),
+        ),
+        ClientConfiguration(),
+      );
+
+      final user1a = await Eppo.forSubject('user-1');
+      final user1b = await Eppo.forSubject('user-1');
+
+      expect(Eppo.activeSubjects.length, 1);
+      expect(Eppo.activeSubjects, contains('user-1'));
+    });
+
+    test('removeSubject removes instance', () async {
+      // Initialize the SDK first
+      await Eppo.initialize(
+        'test-sdk-key',
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'initial-user'),
+        ),
+        ClientConfiguration(),
+      );
+
+      await Eppo.forSubject('user-1');
+      expect(Eppo.activeSubjects.length, 1);
+
+      Eppo.removeSubject('user-1');
+      expect(Eppo.activeSubjects.length, 0);
+    });
+
+    test('reset clears all instances', () async {
+      // Initialize the SDK first
+      await Eppo.initialize(
+        'test-sdk-key',
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'initial-user'),
+        ),
+        ClientConfiguration(),
+      );
+
+      await Eppo.forSubject('user-1');
+      await Eppo.forSubject('user-2');
+      expect(Eppo.activeSubjects.length, 2);
+
+      Eppo.reset();
+      expect(Eppo.activeSubjects.length, 0);
+    });
+
+    test('EppoInstance provides all flag evaluation methods', () async {
+      // Initialize the SDK first
+      await Eppo.initialize(
+        'test-sdk-key',
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'initial-user'),
+        ),
+        ClientConfiguration(),
+      );
+
+      final instance = await Eppo.forSubject('test-user');
+
+      // Test that all methods exist and return default values
+      expect(instance.getStringAssignment('test-flag', 'default'), 'default');
+      expect(instance.getBooleanAssignment('test-flag', false), false);
+      expect(instance.getIntegerAssignment('test-flag', 42), 42);
+      expect(instance.getNumericAssignment('test-flag', 3.14), 3.14);
+      expect(instance.getJSONAssignment('test-flag', {'key': 'value'}), {'key': 'value'});
+      
+      final banditResult = instance.getBanditAction('test-flag', 'default');
+      expect(banditResult.variation, 'default');
+      expect(banditResult.action, null);
+    });
+  });
+}

--- a/test/multi_instance_test.dart
+++ b/test/multi_instance_test.dart
@@ -1,5 +1,5 @@
 import 'package:test/test.dart';
-import '../lib/eppo.dart';
+import 'package:eppo/eppo.dart';
 
 void main() {
   group('Multi-Instance Support', () {
@@ -60,8 +60,8 @@ void main() {
         ClientConfiguration(),
       );
 
-      final user1a = await Eppo.forSubject('user-1');
-      final user1b = await Eppo.forSubject('user-1');
+      await Eppo.forSubject('user-1');
+      await Eppo.forSubject('user-1'); // Second call should reuse existing instance
 
       expect(Eppo.activeSubjects.length, 1);
       expect(Eppo.activeSubjects, contains('user-1'));

--- a/test/multi_instance_test.dart
+++ b/test/multi_instance_test.dart
@@ -45,7 +45,8 @@ void main() {
 
       expect(user1, isA<EppoInstance>());
       expect(user2, isA<EppoInstance>());
-      expect(Eppo.activeSubjects.length, 2);
+      expect(Eppo.activeSubjects.length, 3); // initial-user + user-1 + user-2
+      expect(Eppo.activeSubjects, contains('initial-user'));
       expect(Eppo.activeSubjects, contains('user-1'));
       expect(Eppo.activeSubjects, contains('user-2'));
     });
@@ -63,7 +64,8 @@ void main() {
       await Eppo.forSubject('user-1');
       await Eppo.forSubject('user-1'); // Second call should reuse existing instance
 
-      expect(Eppo.activeSubjects.length, 1);
+      expect(Eppo.activeSubjects.length, 2); // initial-user + user-1
+      expect(Eppo.activeSubjects, contains('initial-user'));
       expect(Eppo.activeSubjects, contains('user-1'));
     });
 
@@ -78,10 +80,11 @@ void main() {
       );
 
       await Eppo.forSubject('user-1');
-      expect(Eppo.activeSubjects.length, 1);
+      expect(Eppo.activeSubjects.length, 2); // initial-user + user-1
 
       Eppo.removeSubject('user-1');
-      expect(Eppo.activeSubjects.length, 0);
+      expect(Eppo.activeSubjects.length, 1); // only initial-user remains
+      expect(Eppo.activeSubjects, contains('initial-user'));
     });
 
     test('reset clears all instances', () async {
@@ -96,7 +99,7 @@ void main() {
 
       await Eppo.forSubject('user-1');
       await Eppo.forSubject('user-2');
-      expect(Eppo.activeSubjects.length, 2);
+      expect(Eppo.activeSubjects.length, 3); // initial-user + user-1 + user-2
 
       Eppo.reset();
       expect(Eppo.activeSubjects.length, 0);
@@ -124,6 +127,131 @@ void main() {
       final banditResult = instance.getBanditAction('test-flag', 'default');
       expect(banditResult.variation, 'default');
       expect(banditResult.action, null);
+    });
+
+    test('singleton and multi-instance share same storage', () async {
+      // Initialize the SDK with a specific subject
+      await Eppo.initialize(
+        'test-sdk-key',
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'singleton-user'),
+        ),
+        ClientConfiguration(),
+      );
+
+      // The singleton instance should be available
+      expect(Eppo.instance, isNotNull);
+      
+      // Getting an instance for the same subject should return the same client
+      final sameSubjectInstance = await Eppo.forSubject('singleton-user');
+      expect(sameSubjectInstance, isA<EppoInstance>());
+      
+      // Should only have one instance total
+      expect(Eppo.activeSubjects.length, 1);
+      expect(Eppo.activeSubjects, contains('singleton-user'));
+      
+      // Removing the singleton subject should clear the singleton instance too
+      Eppo.removeSubject('singleton-user');
+      expect(Eppo.instance, isNull);
+      expect(Eppo.activeSubjects.length, 0);
+    });
+
+    test('concurrent forSubject calls create only one instance', () async {
+      // Initialize the SDK first
+      await Eppo.initialize(
+        'test-sdk-key',
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'initial-user'),
+        ),
+        ClientConfiguration(),
+      );
+
+      // Make multiple concurrent calls for the same subject
+      final futures = <Future<EppoInstance>>[];
+      for (int i = 0; i < 5; i++) {
+        futures.add(Eppo.forSubject('concurrent-user'));
+      }
+
+      // Wait for all to complete
+      final instances = await Future.wait(futures);
+
+      // Should only create one instance total (initial-user + concurrent-user)
+      expect(Eppo.activeSubjects.length, 2);
+      expect(Eppo.activeSubjects, contains('initial-user'));
+      expect(Eppo.activeSubjects, contains('concurrent-user'));
+
+      // All returned instances should be for the same underlying client
+      expect(instances.length, 5);
+      for (final instance in instances) {
+        expect(instance, isA<EppoInstance>());
+      }
+    });
+
+    test('client is available immediately after creation', () async {
+      // Initialize the SDK first
+      await Eppo.initialize(
+        'test-sdk-key',
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'initial-user'),
+        ),
+        ClientConfiguration(),
+      );
+
+      // The singleton instance should be available immediately after initialize
+      expect(Eppo.instance, isNotNull);
+      expect(Eppo.activeSubjects, contains('initial-user'));
+
+      // Start creating a new subject instance
+      final futureInstance = Eppo.forSubject('new-user');
+      
+      // The subject should appear in activeSubjects immediately
+      // (even though forSubject hasn't completed yet)
+      expect(Eppo.activeSubjects, contains('new-user'));
+      
+      // Complete the creation
+      final instance = await futureInstance;
+      expect(instance, isA<EppoInstance>());
+      
+      // Should still be there after completion
+      expect(Eppo.activeSubjects, contains('new-user'));
+    });
+
+    test('singleton API works seamlessly with forSubject API', () async {
+      // 1. Start with singleton API
+      await Eppo.initialize(
+        'test-sdk-key',
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'user-123'),
+        ),
+        ClientConfiguration(),
+      );
+
+      // 2. Use singleton methods
+      expect(Eppo.instance, isNotNull);
+      String singletonResult = Eppo.getStringAssignment('test-flag', 'default');
+      expect(singletonResult, 'default');
+
+      // 3. Use forSubject with same subject key as singleton
+      final sameUserInstance = await Eppo.forSubject('user-123');
+      expect(sameUserInstance, isA<EppoInstance>());
+      
+      // Should return same results as singleton (same underlying client)
+      String instanceResult = sameUserInstance.getStringAssignment('test-flag', 'default');
+      expect(instanceResult, singletonResult);
+
+      // 4. Use forSubject with different subject key
+      final otherUserInstance = await Eppo.forSubject('user-456');
+      expect(otherUserInstance, isA<EppoInstance>());
+
+      // 5. Verify storage
+      expect(Eppo.activeSubjects.length, 2);
+      expect(Eppo.activeSubjects, contains('user-123')); // Singleton subject
+      expect(Eppo.activeSubjects, contains('user-456')); // Multi-instance subject
+
+      // 6. Singleton should still work
+      expect(Eppo.instance, isNotNull);
+      String stillWorking = Eppo.getStringAssignment('test-flag', 'default');
+      expect(stillWorking, 'default');
     });
   });
 }

--- a/test/multi_instance_test.dart
+++ b/test/multi_instance_test.dart
@@ -10,7 +10,11 @@ void main() {
 
     test('forSubject throws StateError when not initialized', () async {
       expect(
-        () async => await Eppo.forSubject('test-user'),
+        () async => await Eppo.forSubject(
+          SubjectEvaluation(
+            subject: Subject(subjectKey: 'test-user'),
+          ),
+        ),
         throwsA(isA<StateError>()),
       );
     });
@@ -26,7 +30,11 @@ void main() {
       );
 
       // Should not throw
-      final instance = await Eppo.forSubject('test-user');
+      final instance = await Eppo.forSubject(
+        SubjectEvaluation(
+          subject: Subject(subjectKey: 'test-user'),
+        ),
+      );
       expect(instance, isA<EppoPrecomputedClient>());
     });
 
@@ -40,8 +48,8 @@ void main() {
         ClientConfiguration(),
       );
 
-      final user1 = await Eppo.forSubject('user-1');
-      final user2 = await Eppo.forSubject('user-2');
+      final user1 = await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'user-1')));
+      final user2 = await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'user-2')));
 
       expect(user1, isA<EppoPrecomputedClient>());
       expect(user2, isA<EppoPrecomputedClient>());
@@ -61,8 +69,8 @@ void main() {
         ClientConfiguration(),
       );
 
-      await Eppo.forSubject('user-1');
-      await Eppo.forSubject('user-1'); // Second call should reuse existing instance
+      await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'user-1')));
+      await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'user-1'))); // Second call should reuse existing instance
 
       expect(Eppo.activeSubjects.length, 2); // initial-user + user-1
       expect(Eppo.activeSubjects, contains('initial-user'));
@@ -79,7 +87,7 @@ void main() {
         ClientConfiguration(),
       );
 
-      await Eppo.forSubject('user-1');
+      await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'user-1')));
       expect(Eppo.activeSubjects.length, 2); // initial-user + user-1
 
       Eppo.removeSubject('user-1');
@@ -97,8 +105,8 @@ void main() {
         ClientConfiguration(),
       );
 
-      await Eppo.forSubject('user-1');
-      await Eppo.forSubject('user-2');
+      await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'user-1')));
+      await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'user-2')));
       expect(Eppo.activeSubjects.length, 3); // initial-user + user-1 + user-2
 
       Eppo.reset();
@@ -115,7 +123,7 @@ void main() {
         ClientConfiguration(),
       );
 
-      final instance = await Eppo.forSubject('test-user');
+      final instance = await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'test-user')));
 
       // Test that all methods exist and return default values
       expect(instance.getStringAssignment('test-flag', 'default'), 'default');
@@ -143,7 +151,7 @@ void main() {
       expect(Eppo.instance, isNotNull);
       
       // Getting an instance for the same subject should return the same client
-      final sameSubjectInstance = await Eppo.forSubject('singleton-user');
+      final sameSubjectInstance = await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'singleton-user')));
       expect(sameSubjectInstance, isA<EppoPrecomputedClient>());
       
       // Should only have one instance total
@@ -169,7 +177,7 @@ void main() {
       // Make multiple concurrent calls for the same subject
       final futures = <Future<EppoPrecomputedClient>>[];
       for (int i = 0; i < 5; i++) {
-        futures.add(Eppo.forSubject('concurrent-user'));
+        futures.add(Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'concurrent-user'))));
       }
 
       // Wait for all to complete
@@ -202,7 +210,7 @@ void main() {
       expect(Eppo.activeSubjects, contains('initial-user'));
 
       // Start creating a new subject instance
-      final futureInstance = Eppo.forSubject('new-user');
+      final futureInstance = Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'new-user')));
       
       // The subject should appear in activeSubjects immediately
       // (even though forSubject hasn't completed yet)
@@ -232,7 +240,7 @@ void main() {
       expect(singletonResult, 'default');
 
       // 3. Use forSubject with same subject key as singleton
-      final sameUserInstance = await Eppo.forSubject('user-123');
+      final sameUserInstance = await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'user-123')));
       expect(sameUserInstance, isA<EppoPrecomputedClient>());
       
       // Should return same results as singleton (same underlying client)
@@ -240,7 +248,7 @@ void main() {
       expect(instanceResult, singletonResult);
 
       // 4. Use forSubject with different subject key
-      final otherUserInstance = await Eppo.forSubject('user-456');
+      final otherUserInstance = await Eppo.forSubject(SubjectEvaluation(subject: Subject(subjectKey: 'user-456')));
       expect(otherUserInstance, isA<EppoPrecomputedClient>());
 
       // 5. Verify storage


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Customers' applications might need to concurrently support multiple subjects, such as in the case of an anonymous (not yet registered) and logged-in user. Today there is a singleton client and when a new context is requested, the existing one is overwritten, blocking multiple subject support.

We need to extend the API to allow using multiple subjects, but keep the API simple for most users who will just need a single one.

## Description
[//]: # (Describe your changes in detail)

Adds capability to maintain multiple clients with a new constructor `forSubject`.

Since the new APIs are purely additive, I am bumping the minor version and not major.

## For Reviewers

I am unsure if locking is needed for access to the singleton map - we've been burned before when accessing shared resources on mobile so I added one.

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)

Added to `README` file.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

✔️ New integration test passes

✔️ ran example app using live SDK token

```
dart example/main.dart CLIENTTOKEN 123

🚀 Eppo SDK Multi-Instance Example
===================================

📱 Part 1: Singleton API
-------------------------
✅ Initialized SDK for logged-in user: 123
logAssignment: premium-feature true 2025-07-29 12:36:42.280559Z
   Premium feature enabled: true

👥 Part 2: Multi-Instance API
------------------------------
✅ Created anonymous user instance
✅ Created second user instance

🔍 Part 3: Flag Evaluations Per User
------------------------------------
logAssignment: premium-feature true 2025-07-29 12:36:42.401224Z
Anonymous user flags:
   Premium feature: true
   Show signup banner: false
logAssignment: premium-feature true 2025-07-29 12:36:42.401652Z

Second user flags:
   Premium feature: true
   Show signup banner: false

🔗 Part 4: API Coexistence
--------------------------
Singleton API result: true
Multi-instance API (same subject): true
Results match: true

📊 Part 5: Instance Management
------------------------------
Active subjects: [123, anonymous-session-abc123, user-456]
Total instances: 3

Cleaning up anonymous user...
Active subjects after cleanup: [123, user-456]

🔄 Part 6: User State Transition
---------------------------------
Simulating anonymous → logged-in user transition...
Before login - signup banner: false
logAssignment: premium-feature true 2025-07-29 12:36:42.517685Z
After login - premium feature: true

✨ Example completed successfully!
Final active subjects: [123, user-456, user-789]
```